### PR TITLE
Add functionality to invert colors

### DIFF
--- a/PyReconstruct/modules/backend/view/section_layer.py
+++ b/PyReconstruct/modules/backend/view/section_layer.py
@@ -1,4 +1,4 @@
-from PySide6.QtGui import QPainter, QPixmap
+from PySide6.QtGui import QPainter, QPixmap, QImage
 from PySide6.QtCore import Qt
 
 from .image_layer import ImageLayer
@@ -32,7 +32,8 @@ class SectionLayer(ImageLayer, TraceLayer):
         generate_traces=True,
         hide_traces=False,
         show_all_traces=False,
-        hide_image=False
+        hide_image=False,
+        invert_image=False
         ):
         """Generate pixmap view for a section.
         
@@ -56,6 +57,12 @@ class SectionLayer(ImageLayer, TraceLayer):
             self.image_layer.fill(Qt.black)
         elif generate_image:
             self.image_layer = self.generateImageLayer(pixmap_dim, window)
+        
+        # Invert base color if requested
+        if invert_image:
+            temp_img = self.image_layer.toImage()
+            temp_img.invertPixels(QImage.InvertRgb)
+            self.image_layer = QPixmap.fromImage(temp_img)
         
         ## Hide all traces if requested
         if hide_traces:

--- a/PyReconstruct/modules/datatypes/default_settings.py
+++ b/PyReconstruct/modules/datatypes/default_settings.py
@@ -53,6 +53,7 @@ default_settings = {
     "screenshot_res": 300,
     "show_ztraces": True,  # MFO
     "fill_opacity": 0.2,  # MFO
+    "invert_colors": False,  # MFO
     "find_zoom": 95.0,  # MFO
     "show_flags": "unresolved",  # MFO
     "display_closest": True,  # MFO

--- a/PyReconstruct/modules/gui/main/field_widget_1_base.py
+++ b/PyReconstruct/modules/gui/main/field_widget_1_base.py
@@ -127,6 +127,9 @@ class FieldWidgetBase:
         ## Create zarr view if applicable
         self.createZarrLayer()
         
+        # Reset invert color option to false
+        self.series.setOption("invert_colors", False)
+        
         ## Reset b section and layer
         self.b_section = None
         self.b_section_layer = None
@@ -258,6 +261,9 @@ class FieldWidgetBase:
         assert(abs(x_scaling - y_scaling) < 1e-6)
         
         self.scaling = x_scaling
+        
+        # check if image should be inverted
+        invert_image = self.series.getOption("invert_colors")
 
         ## Generate section view
         view = self.section_layer.generateView(
@@ -267,7 +273,8 @@ class FieldWidgetBase:
             generate_traces=generate_traces,
             hide_traces=self.hide_trace_layer,
             show_all_traces=self.show_all_traces,
-            hide_image=self.hide_image
+            hide_image=self.hide_image,
+            invert_image=invert_image
         )
 
         # blend b section if requested
@@ -312,6 +319,11 @@ class FieldWidgetBase:
         if update:
             self.update()
     
+    def toggleInvertColors(self):
+        current = self.series.getOption("invert_colors")
+        self.series.setOption("invert_colors", not current)
+        self.generateView()
+        
     def clearStates(self) -> None:
         """Create/clear the states for each section."""
         self.series_states = SeriesStates(self.series)

--- a/PyReconstruct/modules/gui/main/menubar.py
+++ b/PyReconstruct/modules/gui/main/menubar.py
@@ -330,8 +330,9 @@ def return_view_menu(self):
             ("viewmag_act", "View magnification...", "", self.field.setViewMagnification),
             ("findview_act", "Set zoom when finding contours...", "", self.setFindZoom),
             None,
-            ("toggleztraces_act", "Toggle show Z-traces", "", self.toggleZtraces),
+            ("toggleztraces_act", "Toggle show Z-traces", "", self.toggleZtraces),            
             None,
+            ("invertcolors_act", "Invert Colors", "checkbox", self.field.toggleInvertColors),
             {
                 "attr_name": "palettemenu",
                 "text": "Palette",


### PR DESCRIPTION
# Image Color Inversion

### Summary

I've found that switching between normal and inverted colors making it easier for me to trace. Sooo....
This code introduces an `Invert Colors` checkbox under the `View` tab. It allows users to toggle between normal and inverted colors.

### Changes Introduced

- Added a checkbox under the View tab to toggle color inversion.
- Inverts the RGB values of the displayed image.
- **Trace colors remain unaffected**.
- The setting resets to “False” on startup.

