### PR TITLE
Added macOS compatibility for the dev setup script.

### DIFF
--- a/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
+++ b/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
@@ -9,11 +9,28 @@ import zarr
 os.environ["OPENCV_LOG_LEVEL"] = "FATAL"
 os.environ["OPENCV_IO_MAX_IMAGE_PIXELS"] = "18500000000"  # Go big or go home?
 
+def clean_windows_path(path):
+    
+    if not sys.platform.startswith('win'):
+        return path
+        
+    # Remove surrounding quotes if present
+    if (path.startswith('"') and path.endswith('"')) or (path.startswith("'") and path.endswith("'")):
+        path = path[1:-1]
+    
+    # Handle paths with nested quotes
+    path = path.replace('""', '"').replace("''", "'")
+    
+    # Replace forward slashes with backslashes for Windows
+    path = path.replace('/', '\\')
+    
+    return path
+
 cores = int(sys.argv[1])  # number of cores to use
 
 if len(sys.argv) == 4:
-    
-    img_dir = sys.argv[2]
+
+    img_dir = clean_windows_path(sys.argv[2])
     zarr_fp = sys.argv[3]
     create_new = True
     

--- a/PyReconstruct/modules/backend/func/import_swift_transforms.py
+++ b/PyReconstruct/modules/backend/func/import_swift_transforms.py
@@ -88,7 +88,7 @@ def make_pyr_transforms(project_file, scale=1, cal_grid=False):
             width_ratio = img_width_1 / img_width  # left here for now 
         
             # Get section transform, make sane, append to list
-            transform = scale_req.get("cafm")
+            transform = scale_req.get("alt_cafm")
             transform = cafm_to_sanity(transform, dim=img_height, scale_ratio=height_ratio)
             pyr_transforms.append(transform)
 

--- a/PyReconstruct/modules/backend/volume/objects_3D.py
+++ b/PyReconstruct/modules/backend/volume/objects_3D.py
@@ -59,6 +59,7 @@ class Object3D():
             if s < self.extremes[4]: self.extremes[4] = s
             if s > self.extremes[5]: self.extremes[5] = s
 
+
 class Surface(Object3D):
 
     def __init__(self, *args):
@@ -256,6 +257,7 @@ class Spheres(Object3D):
         }
         
         return mesh_data
+
 
 class Contours(Object3D):
 

--- a/PyReconstruct/modules/datatypes/series_data.py
+++ b/PyReconstruct/modules/datatypes/series_data.py
@@ -1,4 +1,5 @@
 """Collect data to pass to table manager."""
+
 from typing import Union
 
 from PyReconstruct.modules.calc import lineDistance, area
@@ -345,8 +346,15 @@ class SeriesData():
             
             for trace_data in trace_list:
                 v += trace_data.getArea() * self.data["sections"][snum]["thickness"]
-                
+        
         return v
+
+    def getSurfaceArea(self, obj_name: str) -> float:
+        """Get the surface area of an object."""
+
+        from PyReconstruct.modules.backend.volume.export_volumes import get_3D_mesh
+
+        pass
 
     def getConfiguration(self, obj_name: str) -> Union[str, None]:
         """Get the configuration of the object.

--- a/PyReconstruct/modules/gui/main/context_menu_list.py
+++ b/PyReconstruct/modules/gui/main/context_menu_list.py
@@ -121,7 +121,7 @@ def get_context_menu_list_obj(self):
                 ("removeobj3D_act", "Remove from scene", "", self.remove3D),
                 {
                     "attr_name": "exportobj3D",
-                    "text": "Export",
+                    "text": "Export meshes",
                     "opts":
                     [
                         ("export3D_act", "Wavefront (.obj)", "", lambda : self.exportAs3D("obj")),
@@ -132,6 +132,7 @@ def get_context_menu_list_obj(self):
                     ]
                     
                     },
+                ("exportmeshdata", "Export quantitative data", "", self.export3DData),
                 None,
                 ("editobj3D_act", "Edit 3D settings...", "", self.edit3D)
             ]

--- a/PyReconstruct/modules/gui/main/field_widget_3_object.py
+++ b/PyReconstruct/modules/gui/main/field_widget_3_object.py
@@ -311,6 +311,11 @@ class FieldWidgetObject(FieldWidgetTrace):
         """Export 3D objects."""
         self.mainwindow.exportAs3D(obj_names, export_type)
 
+    @object_function(update_objects=False, reload_field=False)
+    def export3DData(self, obj_names: list):
+        """Export quantitative data from 3D meshes."""
+        self.mainwindow.export3DData(obj_names)
+        
     @object_function(update_objects=True, reload_field=False)
     def addToGroup(self, obj_names : list, log_event=True):
         """Add objects to a group."""

--- a/PyReconstruct/modules/gui/main/main_imports.py
+++ b/PyReconstruct/modules/gui/main/main_imports.py
@@ -108,7 +108,8 @@ from PyReconstruct.modules.backend.autoseg import (
 )
 
 from PyReconstruct.modules.backend.volume import (
-    export3DObjects
+    export3DObjects,
+    export3DData
 )
 
 from PyReconstruct.modules.backend.imports import (

--- a/PyReconstruct/modules/gui/main/main_window.py
+++ b/PyReconstruct/modules/gui/main/main_window.py
@@ -855,7 +855,7 @@ class MainWindow(QMainWindow):
         ## Convert series
         jsonToXML(self.series, os.path.dirname(export_fp))
 
-        notify("Legacy series (xml) exported to:\n\n{os.path.dirname(export_fp)}")
+        notify(f"Legacy series (xml) exported to:\n\n{os.path.dirname(export_fp)}")
     
     def seriesModified(self, modified=True):
         """Change the title of the window reflect modifications."""

--- a/PyReconstruct/modules/gui/main/main_window.py
+++ b/PyReconstruct/modules/gui/main/main_window.py
@@ -2372,6 +2372,25 @@ class MainWindow(QMainWindow):
             )
         if not export_dir: return
         export3DObjects(self.series, obj_names, export_dir, export_type)
+
+    def export3DData(self, obj_names):
+        """Export quantitative data from meshes."""
+        
+        notify(
+            f"3D surface area and volume measurements depend on the meshing algorithm "
+            f"implemented in PyReconstruct. We recommend verifying proper mesh quality by "
+            f"inspecting objects in the 3D scene before analyzing quantitative data.\n\n"
+            f"Click OK to specificy where to save this data."
+        )
+        
+        self.saveAllData()
+        
+        output_fp = FileDialog.get(
+            "save", self, "Save data as CSV file", "*.csv", "mesh_data.csv"
+        )
+        if not output_fp: return
+
+        export3DData(self.series, obj_names, output_fp)
     
     def toggleCuration(self):
         """Quick shortcut to toggle curation on/off for the tables."""

--- a/PyReconstruct/modules/gui/table/object.py
+++ b/PyReconstruct/modules/gui/table/object.py
@@ -883,7 +883,7 @@ class ObjectTableWidget(DataTable):
             return
         
         self.series.exportUserColsText(out_fp)
-    
+
     def importUserColText(self):
         """Import user columns from a text file."""
         fp = FileDialog.get(

--- a/dev/link_shell.sh
+++ b/dev/link_shell.sh
@@ -1,37 +1,56 @@
-#!/usr/bin/sh
+#!/bin/bash
+set -euo pipefail
 
-# ENV_DIR provided by Makefile
+# Ensure ENV_DIR is set
+if [[ -z "${ENV_DIR:-}" ]]; then
+  echo "Error: ENV_DIR is not set. Please export it or pass it via the Makefile."
+  exit 1
+fi
 
-ENV_BIN=$ENV_DIR/bin
-ENV_ETC=$ENV_DIR/etc/conda
+ENV_BIN="$ENV_DIR/bin"
+ENV_ETC="$ENV_DIR/etc/conda"
+
+mkdir -p "$ENV_ETC/activate.d" "$ENV_ETC/deactivate.d"
 
 #### HOOKS #########################################################################################
 
 echo 'Adding to pre/post-activate hooks...'
 
-scripts_dir=$(realpath .)/scripts
+# Resolve absolute path to ./scripts (fallback if realpath not installed)
+if command -v realpath &> /dev/null; then
+  scripts_dir="$(realpath ./scripts)"
+else
+  scripts_dir="$(cd ./scripts && pwd)"
+fi
 
-# Make sure shell scripts executable
-for script in $scripts_dir/* ; do
-  chmod +x $script
-done
+# Make sure scripts are executable
+if [ -d "$scripts_dir" ]; then
+  for script in "$scripts_dir"/* ; do
+    [ -f "$script" ] && chmod +x "$script"
+  done
+fi
 
-# Amend activation hooks
-for script in env_tweaks/activate/* ; do
-  cp $script $ENV_ETC/activate.d/
-done
+# Copy activation scripts
+if [ -d env_tweaks/activate ]; then
+  for script in env_tweaks/activate/* ; do
+    [ -f "$script" ] && cp "$script" "$ENV_ETC/activate.d/"
+  done
+fi
 
-# Add $scripts_dir to path on activation
-echo "link_pr_scripts $scripts_dir" >> $ENV_ETC/activate.d/path.sh
+# Add $scripts_dir to PATH on activation
+echo "link_pr_scripts \"$scripts_dir\"" >> "$ENV_ETC/activate.d/path.sh"
 
-# Amend deactivation hooks
-for script in env_tweaks/deactivate/* ; do
-  cp $script $ENV_ETC/deactivate.d/
-done
+# Copy deactivation scripts
+if [ -d env_tweaks/deactivate ]; then
+  for script in env_tweaks/deactivate/* ; do
+    [ -f "$script" ] && cp "$script" "$ENV_ETC/deactivate.d/"
+  done
+fi
 
-# Remove $scripts_dir from path on deactivation
-deactivate_path=$ENV_ETC/deactivate.d/path.sh
-echo "REMOVE=$scripts_dir" | cat - $deactivate_path > temp && mv temp $deactivate_path
+# Remove $scripts_dir from PATH on deactivation
+deactivate_path="$ENV_ETC/deactivate.d/path.sh"
+touch "$deactivate_path"
+echo "REMOVE=\"$scripts_dir\"" | cat - "$deactivate_path" > "${deactivate_path}.tmp" && mv "${deactivate_path}.tmp" "$deactivate_path"
 
 echo 'Hooks amended.'
 
@@ -39,21 +58,48 @@ echo 'Hooks amended.'
 
 echo 'Adding repo to sys.path...'
 
-REPO_PATH=$(realpath ..)
-PYTHON=$($ENV_BIN/python -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')")
-SITE_PKGS=$ENV_DIR/lib/$PYTHON/site-packages
-CONDA_PTH=$SITE_PKGS/conda.pth
+# Resolve repo path (../ relative to script location)
+if command -v realpath &> /dev/null; then
+  REPO_PATH="$(realpath ..)"
+else
+  REPO_PATH="$(cd .. && pwd)"
+fi
 
-if [ ! -f $CONDA_PTH ] || ! grep -q $REPO_PATH $CONDA_PTH ; then
-  echo $REPO_PATH >> $CONDA_PTH
+PYTHON_BIN="$ENV_BIN/python"
+if [ ! -x "$PYTHON_BIN" ]; then
+  echo "Error: Python binary not found at $PYTHON_BIN"
+  exit 1
+fi
+
+PYTHON_VER=$("$PYTHON_BIN" -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')")
+SITE_PKGS="$ENV_DIR/lib/$PYTHON_VER/site-packages"
+CONDA_PTH="$SITE_PKGS/conda.pth"
+
+mkdir -p "$SITE_PKGS"
+
+# Add repo path to conda.pth if not already present
+if [ ! -f "$CONDA_PTH" ] || ! grep -Fxq "$REPO_PATH" "$CONDA_PTH"; then
+  echo "$REPO_PATH" >> "$CONDA_PTH"
 fi
 
 echo 'Repo added to sys.path.'
 
+#### sitecustomize.py ##############################################################################
+
 echo 'Adding Python tweaks...'
 
-echo 'import sys'                                                >> $SITE_PKGS/sitecustomize.py
-echo 'from PyReconstruct.modules.datatypes.series import Series' >> $SITE_PKGS/sitecustomize.py
-echo 'sys.modules["__main__"].open_series = Series.openJser'     >> $SITE_PKGS/sitecustomize.py
+SITECUSTOM="$SITE_PKGS/sitecustomize.py"
+touch "$SITECUSTOM"
+
+# Only add lines if not already present
+add_if_missing() {
+  local line="$1"
+  local file="$2"
+  grep -Fq "$line" "$file" || echo "$line" >> "$file"
+}
+
+add_if_missing 'import sys' "$SITECUSTOM"
+add_if_missing 'from PyReconstruct.modules.datatypes.series import Series' "$SITECUSTOM"
+add_if_missing 'sys.modules["__main__"].open_series = Series.openJser' "$SITECUSTOM"
 
 echo 'Tweaks done!'


### PR DESCRIPTION
Makes dev/link_shell.sh more portable to work across both macOS and Linux when installing the dev version of PyReconstruct.

Includes:
	•	A proper #!/bin/bash shebang
	•	set -e for early exit on error
	•	Quoted variables to handle spaces
	•	Fallbacks for missing commands like realpath (`coreutils` requires prefixing as `grealpath`)
	•	Conditional checks for missing files or directories
	•	Avoids duplicate edits on repeated runs