### PR TITLE
fix(3D): improve rendering for 3D Scene on high-DPI displays

### DIFF
--- a/PyReconstruct/modules/gui/popup/custom_plotter.py
+++ b/PyReconstruct/modules/gui/popup/custom_plotter.py
@@ -784,6 +784,18 @@ class CustomPlotter(QVTKRenderWindowInteractor):
         ## Create vedo renderer
         self.plt = VPlotter(self, qt_widget=self)
 
+        ## Apply device pixel ratio for macOS Retina displays
+        if "pixel_ratio" in self.screen_info and self.screen_info["pixel_ratio"] > 1.0:
+            render_window = self.GetRenderWindow()
+            if render_window:
+                # Set the device pixel ratio to handle high-DPI displays
+                pixel_ratio = int(self.screen_info["pixel_ratio"])
+                current_size = render_window.GetSize()
+                render_window.SetSize(
+                    current_size[0] * pixel_ratio,
+                    current_size[1] * pixel_ratio
+                )
+
         ## Create menu bar
         menubar_list = [
             {

--- a/PyReconstruct/modules/gui/popup/custom_plotter.py
+++ b/PyReconstruct/modules/gui/popup/custom_plotter.py
@@ -784,7 +784,7 @@ class CustomPlotter(QVTKRenderWindowInteractor):
         ## Create vedo renderer
         self.plt = VPlotter(self, qt_widget=self)
 
-        ## Apply device pixel ratio for macOS Retina displays
+        ## Apply device pixel ratio for high-DPI displays (e.g., MacBook Retina Displays)
         if "pixel_ratio" in self.screen_info and self.screen_info["pixel_ratio"] > 1.0:
             render_window = self.GetRenderWindow()
             if render_window:

--- a/PyReconstruct/modules/gui/utils/utils.py
+++ b/PyReconstruct/modules/gui/utils/utils.py
@@ -40,7 +40,8 @@ def get_screen_info(screen: QScreen) -> dict:
     screen_info = {
         "width"  : screen_rect.width(),
         "height" : screen_rect.height(),
-        "dpi"    : round(screen.physicalDotsPerInch())
+        "dpi"    : round(screen.physicalDotsPerInch()),
+        "pixel_ratio" : screen.devicePixelRatio()
     }
 
     return screen_info


### PR DESCRIPTION
## Summary
- Adds support for high-DPI Retina displays by tracking and applying the device pixel ratio in the 3D scene renderer
- Ensures proper scaling on macOS systems with 2x Retina displays

## Changes
- Add `pixel_ratio` to screen info gathering in `utils.py`
- Apply device pixel ratio scaling to VTK render window in `custom_plotter.py`

## Test plan
- [ ] Test 3D scene rendering on macOS with Retina display
- [ ] Verify rendering of 3D Scene is no longer impacted by improper scaling