### PR TITLE
[codex] Harden Zarr image conversion validation

### DIFF
--- a/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
+++ b/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
@@ -9,6 +9,9 @@ import zarr
 os.environ["OPENCV_LOG_LEVEL"] = "FATAL"
 os.environ["OPENCV_IO_MAX_IMAGE_PIXELS"] = "18500000000"  # Go big or go home?
 
+IMAGE_EXTENSIONS = {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff"}
+MIN_DOWNSAMPLED_PIXELS = 1024**2
+
 def clean_windows_path(path):
     
     if not sys.platform.startswith('win'):
@@ -44,6 +47,82 @@ else:
     print("Please provide arguments", flush=True)
     exit()
 
+def image_filenames(img_dir):
+    images = []
+    skipped = []
+
+    for filename in sorted(os.listdir(img_dir)):
+        img_fp = os.path.join(img_dir, filename)
+        ext = os.path.splitext(filename)[1].lower()
+
+        if not os.path.isfile(img_fp) or ext not in IMAGE_EXTENSIONS:
+            skipped.append(filename)
+            continue
+
+        images.append(filename)
+
+    if skipped:
+        print(
+            "Skipping non-image entries: " + ", ".join(skipped),
+            flush=True
+        )
+
+    if not images:
+        raise Exception(f"No image files found in {img_dir}.")
+
+    return images
+
+
+def scale_names_for_shape(shape):
+    h, w = shape
+    exp = 0
+    scale_names = ["scale_1"]
+
+    while h * w >= MIN_DOWNSAMPLED_PIXELS:
+        h = round(h / 2)
+        w = round(w / 2)
+        exp += 1
+        scale_names.append(f"scale_{2**exp}")
+
+    return scale_names
+
+
+def ensure_scale_groups(zg, images):
+    if create_new:
+        img_fp = os.path.join(img_dir, images[0])
+        cvim = cv2.imread(img_fp, cv2.IMREAD_GRAYSCALE)
+        if cvim is None:
+            raise Exception(f"{images[0]} is not an image file.")
+        scale_names = scale_names_for_shape(cvim.shape)
+    else:
+        first_image = images[0]
+        scale_names = scale_names_for_shape(zg["scale_1"][first_image].shape)
+
+    for scale_group in scale_names:
+        if scale_group not in zg:
+            zg.create_group(scale_group)
+
+
+def validate_zarr(zg, images):
+    missing = []
+
+    for filename in images:
+        if filename not in zg["scale_1"]:
+            missing.append(f"scale_1/{filename}")
+            continue
+
+        for scale_group in scale_names_for_shape(zg["scale_1"][filename].shape)[1:]:
+            if scale_group not in zg or filename not in zg[scale_group]:
+                missing.append(f"{scale_group}/{filename}")
+
+    if missing:
+        preview = "\n".join(missing[:20])
+        remaining = len(missing) - 20
+        if remaining > 0:
+            preview += f"\n... and {remaining} more"
+        raise Exception(f"Zarr conversion incomplete:\n{preview}")
+
+
 def create2D(args):
     zg, filename = args
     
@@ -51,37 +130,31 @@ def create2D(args):
     
     t_start = time.perf_counter()
     
-    try:
-        # get the image
-        if create_new:
-            img_fp = os.path.join(img_dir, filename)
-            cvim = cv2.imread(img_fp, cv2.IMREAD_GRAYSCALE)
-            if cvim is None:
-                raise Exception(f"{filename} is not an image file.")
-            # write raw image into scale 1
-            if filename not in zg["scale_1"]:
-                zg["scale_1"].create_dataset(filename, data=cvim)
-        else:
-            cvim = zg["scale_1"][filename][:]
+    # get the image
+    if create_new:
+        img_fp = os.path.join(img_dir, filename)
+        cvim = cv2.imread(img_fp, cv2.IMREAD_GRAYSCALE)
+        if cvim is None:
+            raise Exception(f"{filename} is not an image file.")
+        # write raw image into scale 1
+        if filename not in zg["scale_1"]:
+            zg["scale_1"].create_dataset(filename, data=cvim)
+    else:
+        cvim = zg["scale_1"][filename][:]
 
-        # keep downsampling image by 2 until size is below 1024x1024 pixels
-        h, w = cvim.shape
-        exp = 0
-        while h * w >= 1024**2:
-            h = round(h/2)
-            w = round(w/2)
-            exp += 1
-            scale_group = f"scale_{2**exp}"
-            if scale_group not in zg:
-                zg.create_group(scale_group)
-            if filename not in zg[scale_group]:
-                downscaled_cvim = cv2.resize(cvim, (w, h))
-                zg[scale_group].create_dataset(filename, data=downscaled_cvim)
-
-    except Exception as e:
-        
-        print(f"Error with {filename}: ", end="", flush=True)
-        print(e, flush=True)
+    # keep downsampling image by 2 until size is below 1024x1024 pixels
+    h, w = cvim.shape
+    exp = 0
+    while h * w >= MIN_DOWNSAMPLED_PIXELS:
+        h = round(h/2)
+        w = round(w/2)
+        exp += 1
+        scale_group = f"scale_{2**exp}"
+        if scale_group not in zg:
+            zg.create_group(scale_group)
+        if filename not in zg[scale_group]:
+            downscaled_cvim = cv2.resize(cvim, (w, h))
+            zg[scale_group].create_dataset(filename, data=downscaled_cvim)
 
     t_end = time.perf_counter()
 
@@ -104,6 +177,15 @@ if __name__ == "__main__":
 
     processes = cores
 
+    if create_new:
+        images = image_filenames(img_dir)
+    else:
+        images = sorted(list(zg["scale_1"]))
+        if not images:
+            raise Exception(f"No scale_1 images found in {zarr_fp}.")
+
+    ensure_scale_groups(zg, images)
+
     while True and processes > 0:
 
         try:
@@ -113,14 +195,6 @@ if __name__ == "__main__":
             t_all_start = time.perf_counter()
 
             with Pool(processes) as p:
-
-                if create_new:
-
-                    images = os.listdir(img_dir)
-                                        
-                else:
-
-                    images = list(zg["scale_1"])
 
                 args = zip([zg] * len(images), images)
                     
@@ -136,9 +210,15 @@ if __name__ == "__main__":
 
             print(f"All tasks completed: {duration} s")
 
+            validate_zarr(zg, images)
+            print("Zarr validation complete.")
+
             break
         
         except Exception as e:
 
             print(f"Failed with core n of {processes} with exception: {e}")
             processes -= 1
+
+    if processes == 0:
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

This hardens the TIFF-to-Zarr conversion script so failed or skipped section images cannot leave behind an apparently successful but incomplete Zarr pyramid.

## Root Cause

The previous converter caught per-image exceptions inside worker processes, printed the error, and still returned success for that image. The top-level conversion could therefore finish with missing `scale_1` sections or missing downsampled scale datasets. The script also iterated every `os.listdir()` entry, so non-image files such as `Thumbs.db` could enter the conversion path.

## Changes

- Filter conversion inputs to known image extensions and skip non-image directory entries with a clear log message.
- Pre-create expected scale groups before multiprocessing begins to avoid scale group creation races between workers.
- Let worker exceptions propagate so conversion retries with fewer cores and ultimately exits non-zero if work cannot complete.
- Validate the finished Zarr pyramid against the expected section/scale datasets before reporting success.
- Return a non-zero process status if all retry attempts fail.

## Validation

- Parsed `PyReconstruct/assets/scripts/convert_zarr/zarree-2.py` with Python `ast.parse`.
- Ran a synthetic TIFF-to-Zarr conversion with three 2048x2048 TIFFs plus a `Thumbs.db` file and verified `scale_1`, `scale_2`, and `scale_4` all contained the expected three section arrays.
- Deleted one lower-scale synthetic dataset, ran update mode, and verified the missing dataset was regenerated and validation passed.
