### PR TITLE
fix(convert): strip quotes from zarr_fp path on Windows scaling

### DIFF
--- a/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
+++ b/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
@@ -34,12 +34,12 @@ cores = int(sys.argv[1])  # number of cores to use
 if len(sys.argv) == 4:
 
     img_dir = clean_windows_path(sys.argv[2])
-    zarr_fp = sys.argv[3]
+    zarr_fp = clean_windows_path(sys.argv[3])
     create_new = True
-    
+
 elif len(sys.argv) == 3:
-    
-    zarr_fp = sys.argv[2]
+
+    zarr_fp = clean_windows_path(sys.argv[2])
     create_new = False
     
 else:


### PR DESCRIPTION
## Problem

On Windows, regenerating scaled images for an already-zarr series fails with:

```
OSError: [WinError 123] The filename, directory name, or volume label syntax
is incorrect: '...\PyReconstruct\"C:'
KeyError: '.zgroup'
```

The zarr path reaches the conversion script wrapped in literal `"` characters, so zarr tries to create a directory whose first component is `"C:`.

## Root cause

`main_window.py` wraps the path in literal double quotes (`f"\"{self.series.src_dir}\""`), which is needed for the Linux `shell=True` invocation. On Windows the command is instead passed as a list through `subprocess.Popen` → `start_process.py` → `QProcess`, and those literal quotes survive into the child process's `argv`.

`zarree-2.py` already cleans `img_dir` with `clean_windows_path()` but never applied it to `zarr_fp` (in either argv branch). In the regenerate-scales path (`zarr.open(zarr_fp)`) the quoted path reached zarr unmodified. Since it begins with a literal `"` rather than a drive letter, `os.path.abspath` treats it as relative and joins it to the cwd, producing the invalid `...\PyReconstruct\"C:` component and the `WinError 123` / `KeyError('.zgroup')` above.

## Fix

Run `zarr_fp` through `clean_windows_path()` in both argv branches, symmetric with how `img_dir` is already handled. The helper early-returns unchanged off Windows, so Linux/macOS behavior is unaffected.

## Testing

- Confirmed the diagnosis against the reported traceback (path resolves to `...\PyReconstruct\"C:` exactly).
- `clean_windows_path()` is a no-op on non-Windows platforms; the create-new path was already passing an unquoted `zarr_fp`, so it is unaffected.
