### PR TITLE
fix(smooth): skip malformed contours when smoothing objects

### DIFF
--- a/PyReconstruct/modules/datatypes/series.py
+++ b/PyReconstruct/modules/datatypes/series.py
@@ -1284,35 +1284,59 @@ class Series():
         
         self.modified = True
 
-    def smoothObject(self, obj_names: list, series_states=None, log_event=True) -> None:
-        """Smooth all traces belonging to an object."""
+    def smoothObject(self, obj_names: list, series_states=None, log_event=True) -> dict:
+        """Smooth all traces belonging to an object.
+
+        Malformed traces with too few points to smooth (e.g. "pixel dust"
+        artifacts) are skipped rather than smoothed.
+
+            Returns:
+                (dict): {obj_name: sorted list of section numbers} for contours
+                    that had one or more traces skipped for being malformed
+        """
 
         window = self.getOption("roll_window")
-        
+
         if log_event:
 
             for obj_name in obj_names:
 
                 self.addLog(obj_name, None, f"Smooth {obj_name} traces")
 
-        for _, section in self.enumerateSections(
+        malformed = {}
+
+        for snum, section in self.enumerateSections(
                 message="Smoothing traces...",
                 series_states=series_states
         ):
-            
+
             for obj_name in obj_names:
-                
+
                 obj = section.contours.get(obj_name)
-                
+
                 if obj:
-                    
-                    section.modified_contours.add(obj_name)
+
+                    smoothed_any = False
+
                     for trace in obj.traces:
-                        trace.smooth(window=window, spacing=0.004)
+
+                        if trace.smooth(window=window, spacing=0.004):
+
+                            smoothed_any = True
+
+                        else:
+
+                            malformed.setdefault(obj_name, set()).add(snum)
+
+                    if smoothed_any:
+
+                        section.modified_contours.add(obj_name)
 
             section.save()
 
             self.modified = True
+
+        return {name: sorted(snums) for name, snums in malformed.items()}
     
     def editObjectRadius(self, obj_names : list, new_rad : float, series_states=None):
         """Change the radii of all traces of an object.

--- a/PyReconstruct/modules/datatypes/trace.py
+++ b/PyReconstruct/modules/datatypes/trace.py
@@ -554,8 +554,20 @@ class Trace():
 
         return intersect_area / union_area
 
-    def smooth(self, window: int, spacing: Union[int, float]) -> None:
-        """Smooth trace."""
+    def smooth(self, window: int, spacing: Union[int, float]) -> bool:
+        """Smooth trace in place.
+
+        Malformed traces with too few points to smooth (e.g. "pixel dust"
+        artifacts) are left untouched.
+
+            Returns:
+                (bool): True if the trace was smoothed, False if it was
+                    skipped for having too few points
+        """
+
+        if len(self.points) < 3:
+
+            return False
 
         unsmoothed = Points(self.points, self.closed)
 
@@ -563,11 +575,17 @@ class Trace():
             spacing, window, as_int=False
         )
 
+        if not smoothed:
+
+            return False
+
         if smoothed[0] == smoothed[-1]:
 
             smoothed = smoothed[:-1]
 
         self.points = smoothed
+
+        return True
 
     @staticmethod
     def get_scale_bar():

--- a/PyReconstruct/modules/gui/main/field_widget_3_object.py
+++ b/PyReconstruct/modules/gui/main/field_widget_3_object.py
@@ -172,10 +172,18 @@ class FieldWidgetObject(FieldWidgetTrace):
 
         self.series_states.addState()
 
-        self.series.smoothObject(
+        malformed = self.series.smoothObject(
             obj_names,
             series_states=self.series_states
         )
+
+        if malformed:
+
+            names = ", ".join(sorted(malformed))
+            notify(
+                "Some contours were skipped because they were malformed "
+                f"(too few points to smooth): {names}"
+            )
 
         return True
     


### PR DESCRIPTION
## Problem

Smoothing all traces of an object crashed when the object had a malformed trace. `Series.smoothObject` ran every trace through `Trace.smooth`, which constructs a `Points` object and indexes `points[0] == points[-1]`. For a trace with too few points (empty, or a degenerate "pixel dust" artifact), that raised `IndexError` partway through and aborted the entire smooth-object operation, leaving the work half-done.

## Fix

- **`Trace.smooth`** now returns early, leaving the trace untouched and returning `False`, when the trace has fewer than 3 points or interpolation produces nothing, and returns `True` when it actually smooths. This also hardens the interactive smooth-trace callers against the same crash.
- **`Series.smoothObject`** uses that return value to skip malformed traces, records which contours were skipped, and returns them as `{obj_name: [section numbers]}`.
- **The object-smoothing GUI action** surfaces a notification listing any skipped contours, so the skip is never silent.

Malformed contours are intentionally left in place for the existing "pixel dust" cleanup step to remove.

## Behavior notes

- A section's contour is now marked modified only when at least one of its traces was actually smoothed (previously it was marked whenever the contour existed).
- Degenerate 2-point traces are now skipped along with empty/1-point ones. They cannot be smoothed meaningfully and fall into the same artifact category.

## Testing

Ran the smoothing pipeline (`Points` → `interp_rolling_average`) in isolation across empty, 1-point, 2-point (distinct and coincident), and valid 3+ point contours:

- Old code: empty / 1-point / coincident 2-point all crashed with `IndexError`.
- New code: those are cleanly skipped (`False`, untouched); valid contours smooth as before.
