### PR TITLE
fix(3D): correct high-DPI coordinate mapping via window device pixel ratio

### DIFF
--- a/PyReconstruct/modules/gui/popup/custom_plotter.py
+++ b/PyReconstruct/modules/gui/popup/custom_plotter.py
@@ -901,7 +901,22 @@ class CustomPlotter(QVTKRenderWindowInteractor):
         self.plt.show(*self.plt.actors, resetcam=(False if load_fp else None))
         self.show()
         self.container.show()
-        
+
+    def _getPixelRatio(self):
+        """Return the device pixel ratio of the screen this widget is on.
+
+        Overrides QVTKRenderWindowInteractor._getPixelRatio, which samples the
+        screen under the mouse cursor (QCursor.pos()). On multi-monitor or
+        fractional-scaling setups that is frequently not the screen the 3D
+        scene is displayed on, so VTK sized the render window and scaled mouse
+        events by the wrong ratio -- the intermittent high-DPI coordinate
+        mapping issue. devicePixelRatioF() always reflects this widget's own
+        screen and is fractional-aware (e.g. 1.25, 1.5), so both the render
+        window sizing (resizeEvent) and the mouse-event scaling
+        (_setEventInformation) stay consistent with what is actually rendered.
+        """
+        return self.devicePixelRatioF()
+
     def keyPressEvent(self, event : QKeyEvent):
         """Filter the keypresses to only use the allowed keys.
         


### PR DESCRIPTION
## Problem

The 3D scene's pick/click coordinates were offset on high-DPI displays. The offset was intermittent across machines and worse at fractional scaling (Windows 125/150/175%).

## Root cause

VTK 9.3.1's `QVTKRenderWindowInteractor` already scales **both** the render-window size (`resizeEvent`) and mouse-event positions (`_setEventInformation`) by `self._getPixelRatio()`. The base implementation, however, samples the device pixel ratio of the screen **under the mouse cursor** (`QCursor.pos()`):

```python
@staticmethod
def _getPixelRatio():
    pos = QCursor.pos()
    for screen in QApplication.screens():
        if screen.geometry().contains(pos):
            return screen.devicePixelRatio()
    return QApplication.instance().devicePixelRatio()
```

On multi-monitor / mixed-DPI setups that screen is frequently **not** the one the 3D window is displayed on, so the render window was sized and clicks were scaled by the wrong ratio, producing the picking offset. Because it depends on where the cursor happens to be, the symptom is intermittent.

(The earlier mitigation on the test branch multiplied the render window size by `int(primary_screen_ratio)` once at construction. `int()` truncated fractional ratios (1.5 → 1), so it only helped integer ratios on a single monitor and did nothing at 125/150/175%.)

## Fix

Override `_getPixelRatio` on `CustomPlotter` to return `self.devicePixelRatioF()`, the fractional-aware device pixel ratio of the screen the widget is actually on. Since the base class calls `self._getPixelRatio()` for both window sizing and mouse-event scaling, this single override keeps both consistent with what is rendered, for integer and fractional ratios, and re-samples as the window moves between screens.

## Verification

- Confirmed VTK 9.3.1 scales size + events via `_getPixelRatio`, and that the base impl is cursor-screen based (source inspection of the bundled `QVTKRenderWindowInteractor.py`).
- Confirmed (standalone test) that a subclass instance method overrides the base `@staticmethod` when the base calls `self._getPixelRatio()`.
- Confirmed vedo's picking has no separate Qt path: `Plotter.fill_event` reads `self.interactor.GetEventPosition()`, which is set by `_setEventInformation` → `_getPixelRatio`, so the override governs `event.picked3d`.

## Testing note

This needs validation on real high-DPI hardware, ideally Windows at 150% scaling and a multi-monitor mixed-DPI setup. The prior class beta test exercised the older `int()` approach, not this override.
