### PR TITLE
feat(convert): harden zarr scaling and add converter progress bar + ETA

### DIFF
--- a/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
+++ b/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
@@ -281,6 +281,11 @@ if __name__ == "__main__":
     processes = max(1, min(cores, MAX_WORKERS))
     print(f"Converting with {processes} worker process(es)...", flush=True)
 
+    total = len(images)
+    # machine-readable progress markers consumed by the converter window
+    # (start_process.py) to drive the progress bar / ETA.
+    print(f"@@PROGRESS@@ TOTAL {total}", flush=True)
+
     t_all_start = time.perf_counter()
 
     # plain, picklable args only -- never the zarr group itself
@@ -289,6 +294,7 @@ if __name__ == "__main__":
         for filename in images
     ]
 
+    done = 0
     with Pool(processes) as p:
 
         # imap (ordered) + main-as-sole-writer => deterministic, race-free writes
@@ -298,7 +304,9 @@ if __name__ == "__main__":
                 if filename not in zg[scale_group]:
                     zg[scale_group].create_dataset(filename, data=arr)
 
+            done += 1
             print(f"Time for conversion {filename}: {round(duration, 2)} s", flush=True)
+            print(f"@@PROGRESS@@ STEP {done} {total}", flush=True)
 
     print(f"All tasks completed: {round(time.perf_counter() - t_all_start, 2)} s", flush=True)
 

--- a/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
+++ b/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
@@ -1,7 +1,8 @@
 import os
 import sys
 import time
-from multiprocessing import Pool
+import shutil
+from multiprocessing import Pool, freeze_support
 
 import cv2
 import zarr
@@ -12,21 +13,29 @@ os.environ["OPENCV_IO_MAX_IMAGE_PIXELS"] = "18500000000"  # Go big or go home?
 IMAGE_EXTENSIONS = {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff"}
 MIN_DOWNSAMPLED_PIXELS = 1024**2
 
+# Cap concurrency: each worker holds a full-resolution tile in memory, and a
+# large worker count multiplies filesystem/metadata pressure for little gain
+# (the work is I/O bound). Bounded well below typical core counts on purpose.
+MAX_WORKERS = 8
+
+# Require a little more free space than estimated before starting.
+DISK_SAFETY_FACTOR = 1.15
+
 def clean_windows_path(path):
-    
+
     if not sys.platform.startswith('win'):
         return path
-        
+
     # Remove surrounding quotes if present
     if (path.startswith('"') and path.endswith('"')) or (path.startswith("'") and path.endswith("'")):
         path = path[1:-1]
-    
+
     # Handle paths with nested quotes
     path = path.replace('""', '"').replace("''", "'")
-    
+
     # Replace forward slashes with backslashes for Windows
     path = path.replace('/', '\\')
-    
+
     return path
 
 cores = int(sys.argv[1])  # number of cores to use
@@ -41,11 +50,29 @@ elif len(sys.argv) == 3:
 
     zarr_fp = clean_windows_path(sys.argv[2])
     create_new = False
-    
+
 else:
 
     print("Please provide arguments", flush=True)
     exit()
+
+
+def open_zarr_with_retry(fp, mode=None, attempts=5, delay=0.2):
+    """Open a zarr store, retrying briefly on transient filesystem errors.
+
+    Network/synced drives (e.g. OneDrive) can momentarily fail to serve a
+    freshly written metadata file; a short backoff absorbs those hiccups
+    instead of crashing.
+    """
+    last_err = None
+    for attempt in range(attempts):
+        try:
+            return zarr.open(fp) if mode is None else zarr.open(fp, mode=mode)
+        except (KeyError, OSError, zarr.errors.GroupNotFoundError) as e:
+            last_err = e
+            time.sleep(delay * (attempt + 1))
+    raise last_err
+
 
 def image_filenames(img_dir):
     images = []
@@ -103,6 +130,64 @@ def ensure_scale_groups(zg, images):
             zg.create_group(scale_group)
 
 
+def _dir_size(path):
+    """Total size of all files under path (metadata-only walk)."""
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                pass
+    return total
+
+
+def estimate_required_bytes(images):
+    """Rough estimate of the additional disk space the scales will need.
+
+    Each halving stores 1/4 the pixels, so the downsampled levels sum to
+    ~1/3 of scale_1 (1/4 + 1/16 + ...). For an existing zarr we measure
+    scale_1's on-disk (compressed) size; for a new zarr we approximate
+    scale_1 from the source image file sizes.
+    """
+    if create_new:
+        src_total = 0
+        for filename in images:
+            try:
+                src_total += os.path.getsize(os.path.join(img_dir, filename))
+            except OSError:
+                pass
+        # new scale_1 (~ source size) plus downscales (~1/3 of scale_1)
+        return int(src_total * (1 + 1 / 3))
+
+    scale1_size = _dir_size(os.path.join(zarr_fp, "scale_1"))
+    # only the downscales are new (~1/3 of scale_1)
+    return int(scale1_size / 3)
+
+
+def check_disk_space(images):
+    """Abort up front if the target volume can't hold the new scales."""
+    required = int(estimate_required_bytes(images) * DISK_SAFETY_FACTOR)
+    target = os.path.dirname(os.path.abspath(zarr_fp)) or "."
+    free = shutil.disk_usage(target).free
+    gb = 1024 ** 3
+
+    print(
+        f"Estimated additional space needed: ~{required / gb:.2f} GB; "
+        f"free on target volume: {free / gb:.2f} GB",
+        flush=True,
+    )
+
+    if free < required:
+        raise SystemExit(
+            "Not enough free disk space to generate scaled images.\n"
+            f"  Estimated need (with margin): ~{required / gb:.2f} GB\n"
+            f"  Available on target volume:   {free / gb:.2f} GB\n"
+            "Free up space or choose an output location with more room, "
+            "then try again."
+        )
+
+
 def validate_zarr(zg, images):
     missing = []
 
@@ -124,58 +209,61 @@ def validate_zarr(zg, images):
 
 
 def create2D(args):
-    zg, filename = args
-    
+    """Worker: read one image and return its resized levels.
+
+    Workers never write to the zarr store -- they only read/compute and hand
+    the arrays back to the main process, which is the sole writer. This keeps
+    the conversion free of cross-process write races and makes a failure
+    (e.g. a full disk) surface once, in the main process.
+    """
+    filename, create_new, img_dir, zarr_fp = args
+
     print(f"Working on {filename}...", flush=True)
-    
+
     t_start = time.perf_counter()
-    
-    # get the image
+
+    scales = {}
+
     if create_new:
         img_fp = os.path.join(img_dir, filename)
         cvim = cv2.imread(img_fp, cv2.IMREAD_GRAYSCALE)
         if cvim is None:
             raise Exception(f"{filename} is not an image file.")
-        # write raw image into scale 1
-        if filename not in zg["scale_1"]:
-            zg["scale_1"].create_dataset(filename, data=cvim)
+        # full-resolution level is written by the main process too
+        scales["scale_1"] = cvim
     else:
-        cvim = zg["scale_1"][filename][:]
+        # read-only handle: concurrent reads are safe and need no disk space
+        src = open_zarr_with_retry(zarr_fp, mode="r")
+        cvim = src["scale_1"][filename][:]
 
-    # keep downsampling image by 2 until size is below 1024x1024 pixels
+    # keep downsampling by 2 until below MIN_DOWNSAMPLED_PIXELS
     h, w = cvim.shape
     exp = 0
     while h * w >= MIN_DOWNSAMPLED_PIXELS:
-        h = round(h/2)
-        w = round(w/2)
+        h = round(h / 2)
+        w = round(w / 2)
         exp += 1
-        scale_group = f"scale_{2**exp}"
-        if scale_group not in zg:
-            zg.create_group(scale_group)
-        if filename not in zg[scale_group]:
-            downscaled_cvim = cv2.resize(cvim, (w, h))
-            zg[scale_group].create_dataset(filename, data=downscaled_cvim)
+        scales[f"scale_{2**exp}"] = cv2.resize(cvim, (w, h))
 
-    t_end = time.perf_counter()
+    return filename, scales, time.perf_counter() - t_start
 
-    return filename, t_end - t_start
 
 if __name__ == "__main__":
 
+    freeze_support()
+
     if create_new:
-        
+
         zg = zarr.group(zarr_fp, overwrite=True)
         zg.create_group("scale_1")
         message = "Converting to zarr now..."
-        
+
     else:
-        
-        zg = zarr.open(zarr_fp)
+
+        zg = open_zarr_with_retry(zarr_fp, mode="a")
         message = "Updating zarr scales now..."
 
-    print(message)
-
-    processes = cores
+    print(message, flush=True)
 
     if create_new:
         images = image_filenames(img_dir)
@@ -184,41 +272,35 @@ if __name__ == "__main__":
         if not images:
             raise Exception(f"No scale_1 images found in {zarr_fp}.")
 
+    # fail fast if the target volume cannot hold the new scales
+    check_disk_space(images)
+
+    # pre-create every scale group up front so workers never create groups
     ensure_scale_groups(zg, images)
 
-    while True and processes > 0:
+    processes = max(1, min(cores, MAX_WORKERS))
+    print(f"Converting with {processes} worker process(es)...", flush=True)
 
-        try:
-            
-            print(f"\n\nAttempting to convert with n cores: {processes}\n\n")
+    t_all_start = time.perf_counter()
 
-            t_all_start = time.perf_counter()
+    # plain, picklable args only -- never the zarr group itself
+    args = [
+        (filename, create_new, img_dir if create_new else None, zarr_fp)
+        for filename in images
+    ]
 
-            with Pool(processes) as p:
+    with Pool(processes) as p:
 
-                args = zip([zg] * len(images), images)
-                    
-                results = p.imap_unordered(create2D, args)
+        # imap (ordered) + main-as-sole-writer => deterministic, race-free writes
+        for filename, scales, duration in p.imap(create2D, args):
 
-                for filename, duration in results:
+            for scale_group, arr in scales.items():
+                if filename not in zg[scale_group]:
+                    zg[scale_group].create_dataset(filename, data=arr)
 
-                    print(f"Time for conversion {filename}: {round(duration, 2)} s")
+            print(f"Time for conversion {filename}: {round(duration, 2)} s", flush=True)
 
-            t_all_end = time.perf_counter()
+    print(f"All tasks completed: {round(time.perf_counter() - t_all_start, 2)} s", flush=True)
 
-            duration = round(t_all_end - t_all_start, 2)
-
-            print(f"All tasks completed: {duration} s")
-
-            validate_zarr(zg, images)
-            print("Zarr validation complete.")
-
-            break
-        
-        except Exception as e:
-
-            print(f"Failed with core n of {processes} with exception: {e}")
-            processes -= 1
-
-    if processes == 0:
-        raise SystemExit(1)
+    validate_zarr(zg, images)
+    print("Zarr validation complete.", flush=True)

--- a/PyReconstruct/assets/scripts/start_process.py
+++ b/PyReconstruct/assets/scripts/start_process.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import (
     QApplication, QMainWindow, QPlainTextEdit, QVBoxLayout, QWidget, QLabel,
     QProgressBar,
 )
-from PySide6.QtCore import QProcess
+from PySide6.QtCore import QProcess, Qt
 
 
 class MainWindow(QMainWindow):
@@ -29,6 +29,7 @@ class MainWindow(QMainWindow):
         self.progress.setTextVisible(True)
 
         self.eta = QLabel("", self)
+        self.eta.setAlignment(Qt.AlignCenter)
 
         self.text = QPlainTextEdit()
         self.text.setReadOnly(True)

--- a/PyReconstruct/assets/scripts/start_process.py
+++ b/PyReconstruct/assets/scripts/start_process.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import time
 from pathlib import Path
 
@@ -150,16 +149,6 @@ class MainWindow(QMainWindow):
             self.eta.setText("Complete.")
 
             self.message("Zarr processing finished.")
-
-            if sys.platform == "linux":
-
-                self.message("Changing file permissions...")
-
-                zarr = sys.argv[3]
-
-                os.system(f"find {zarr} -type d -exec chmod g+rwx {{}} +")
-                os.system(f"find {zarr} -type f -exec chmod g+rw {{}} +")
-
             self.message("You can close this window.")
             self.heading.setText("Zarr processing done. You can safely close this window now.")
 

--- a/PyReconstruct/assets/scripts/start_process.py
+++ b/PyReconstruct/assets/scripts/start_process.py
@@ -1,8 +1,12 @@
 import sys
 import os
+import time
 from pathlib import Path
 
-from PySide6.QtWidgets import QApplication, QMainWindow, QPlainTextEdit, QVBoxLayout, QWidget, QLabel
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QPlainTextEdit, QVBoxLayout, QWidget, QLabel,
+    QProgressBar,
+)
 from PySide6.QtCore import QProcess
 
 
@@ -12,16 +16,27 @@ class MainWindow(QMainWindow):
         super().__init__()
 
         self.p = None
+        self._stdout_buf = ""        # buffers partial (unterminated) stdout lines
+        self._progress_start = None  # set when the first progress total arrives
 
         self.setWindowTitle("Zarr converter")
         self.setGeometry(100, 100, 600, 800)
+
+        self.heading = QLabel("Do not close this window until the process is done.", self)
+
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 0)  # indeterminate until a total is reported
+        self.progress.setTextVisible(True)
+
+        self.eta = QLabel("", self)
 
         self.text = QPlainTextEdit()
         self.text.setReadOnly(True)
 
         l = QVBoxLayout()
-        self.heading = QLabel("Do not close this window until the process is done.", self)
         l.addWidget(self.heading)
+        l.addWidget(self.progress)
+        l.addWidget(self.eta)
         l.addWidget(self.text)
 
         w = QWidget()
@@ -52,10 +67,61 @@ class MainWindow(QMainWindow):
         self.message(stderr)
 
     def handle_stdout(self):
-        
+
         data = self.p.readAllStandardOutput()
-        stdout = bytes(data).decode("utf8").strip()
-        self.message(stdout)
+        self._stdout_buf += bytes(data).decode("utf8", errors="replace")
+
+        # only act on complete lines; keep any trailing partial line buffered
+        *lines, self._stdout_buf = self._stdout_buf.split("\n")
+
+        for line in lines:
+            if line.startswith("@@PROGRESS@@"):
+                self.update_progress(line)
+            elif line.strip():
+                self.message(line)
+
+    def update_progress(self, line):
+        """Drive the progress bar / ETA from a converter progress marker.
+
+        Markers: '@@PROGRESS@@ TOTAL <n>' and '@@PROGRESS@@ STEP <done> <n>'.
+        """
+        parts = line.split()
+        if len(parts) < 3:
+            return
+
+        kind = parts[1]
+
+        if kind == "TOTAL":
+            total = int(parts[2])
+            self.progress.setRange(0, total)
+            self.progress.setValue(0)
+            self._progress_start = time.monotonic()
+            self.eta.setText(f"0 / {total} — estimating time remaining…")
+
+        elif kind == "STEP" and len(parts) >= 4:
+            done, total = int(parts[2]), int(parts[3])
+            if self.progress.maximum() != total:
+                self.progress.setRange(0, total)
+            self.progress.setValue(done)
+            self.eta.setText(self._eta_text(done, total))
+
+    def _eta_text(self, done, total):
+        if not self._progress_start or done <= 0:
+            return f"{done} / {total}"
+        elapsed = time.monotonic() - self._progress_start
+        remaining = (elapsed / done) * (total - done)
+        return f"{done} / {total} — ~{self._format_duration(remaining)} remaining"
+
+    @staticmethod
+    def _format_duration(seconds):
+        seconds = int(max(0, seconds))
+        hours, rem = divmod(seconds, 3600)
+        minutes, secs = divmod(rem, 60)
+        if hours:
+            return f"{hours}h {minutes:02d}m {secs:02d}s"
+        if minutes:
+            return f"{minutes}m {secs:02d}s"
+        return f"{secs}s"
         
     def handle_state(self, state):
         
@@ -67,22 +133,41 @@ class MainWindow(QMainWindow):
         state_name = states[state]
         #self.message(f"State changed: {state_name}")
 
-    def process_finished(self):
-        
-        self.message("Zarr processing finished.")
+    def process_finished(self, exit_code=0, exit_status=None):
 
-        if sys.platform == "linux":
+        # flush any trailing buffered output that lacked a newline
+        if self._stdout_buf.strip():
+            self.message(self._stdout_buf.strip())
+        self._stdout_buf = ""
 
-            self.message("Changing file permissions...")
+        if exit_code == 0:
 
-            zarr = sys.argv[3]
+            # show the bar as complete
+            if self.progress.maximum() == 0:  # was still indeterminate
+                self.progress.setRange(0, 1)
+            self.progress.setValue(self.progress.maximum())
+            self.eta.setText("Complete.")
 
-            os.system(f"find {zarr} -type d -exec chmod g+rwx {{}} +")
-            os.system(f"find {zarr} -type f -exec chmod g+rw {{}} +")
-        
-        self.message("You can close this window.")
-        self.heading.setText("Zarr processing done. You can safely close this window now.")
-        
+            self.message("Zarr processing finished.")
+
+            if sys.platform == "linux":
+
+                self.message("Changing file permissions...")
+
+                zarr = sys.argv[3]
+
+                os.system(f"find {zarr} -type d -exec chmod g+rwx {{}} +")
+                os.system(f"find {zarr} -type f -exec chmod g+rw {{}} +")
+
+            self.message("You can close this window.")
+            self.heading.setText("Zarr processing done. You can safely close this window now.")
+
+        else:
+
+            self.eta.setText("Stopped before completion.")
+            self.message(f"Zarr processing exited with code {exit_code}.")
+            self.heading.setText("Zarr processing did not finish — see messages above.")
+
         self.p = None
 
 


### PR DESCRIPTION
Hardens the zarr scaling conversion and adds progress feedback to the converter window. Two commits: the robustness fix, then the progress bar/ETA.

---

## 1. Race-free conversion + disk-space check

### Problem
Generating scaled images could fail mid-run with a storm of `KeyError: '.zgroup'` / `zarr.errors.GroupNotFoundError` from the pool workers, one traceback per worker, and then quietly give up. It surfaced for a user whose output zarr was on an external drive that ran out of space.

### Root cause
The conversion passed the live zarr **`Group` object to every worker** and the workers all wrote to the **same store concurrently**. On Windows `spawn`, each worker reconstructs the group by re-reading the store's root `.zgroup`; with `cpu_max=100` that's one worker per core. zarr 2.18.2 also applies **no synchronizer to `create_group`**, so concurrent group creation is a genuine race. Any transient filesystem failure (a **full disk**, or a **OneDrive** folder mid-sync) became one crash per core instead of one clear error, and the `while processes > 0: … except: processes -= 1` loop **masked the real cause**, retrying against half-written state until `SystemExit(1)`.

### Fix: main process is the sole writer
- **Workers are pure compute.** They read input and return resized arrays; they never write and the group is never pickled to them. Update mode opens a short-lived **read-only** handle to read `scale_1`.
- **The main process pre-creates every scale group and is the only writer**, consuming results via `imap` (ordered), so writes happen one at a time, in filename order. No concurrent `create_group`, no concurrent dataset writes → **no races by construction**, and a disk-full error surfaces in one place.
- **Pre-flight disk-space check** that estimates the additional space needed (downscales ≈ ⅓ of `scale_1`) and aborts up front with an actionable message.
- **Removed the error-hiding retry loop** so real errors surface immediately.
- Bounded worker count, an open-with-retry helper for transient store reads, and `multiprocessing.freeze_support()`.

**Behavior change:** a genuine error now fails fast with a real traceback instead of silently retrying at lower core counts.

## 2. Progress bar + ETA in the converter window

- `zarree-2.py` emits machine-readable markers from the (now sequential) main write loop: `@@PROGRESS@@ TOTAL <n>` once, then `@@PROGRESS@@ STEP <done> <n>` per image written, so progress reflects real persisted work.
- `start_process.py` renders a `QProgressBar` + ETA label above the log. stdout is line-buffered (markers split across reads parse correctly) and marker lines are kept out of the text log. ETA = elapsed-per-image × remaining, e.g. `120 / 480 — ~3m 20s remaining`.
- Indeterminate until a total arrives (covers the `create_ng_zarr` path, which emits no markers), shows **complete** on a clean exit, and reports **"did not finish"** on a non-zero exit, so the disk-space abort reads clearly rather than looking like success.

## Testing
- create-new and update (zarr containing only `scale_1`, the reported scenario) both produce correct scales and pass validation.
- Disk precheck proceeds when space is ample and aborts early with the clear message when starved (verified with a patched `disk_usage`).
- Validated under forced `spawn` that the new pattern needs no pickled group and that only the main process writes.
- Progress markers emit in order on a real run; the window's consumer logic was unit-tested without a display (marker split across read chunks reassembles, markers excluded from log, ETA + duration formatting correct).

> Full GUI behavior is worth an eyeball on a real conversion. Holding for additional testing with the user base before merge.