### PR TITLE
feat(convert): show progress bar and ETA in the zarr converter window

### DIFF
--- a/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
+++ b/PyReconstruct/assets/scripts/convert_zarr/zarree-2.py
@@ -281,6 +281,11 @@ if __name__ == "__main__":
     processes = max(1, min(cores, MAX_WORKERS))
     print(f"Converting with {processes} worker process(es)...", flush=True)
 
+    total = len(images)
+    # machine-readable progress markers consumed by the converter window
+    # (start_process.py) to drive the progress bar / ETA.
+    print(f"@@PROGRESS@@ TOTAL {total}", flush=True)
+
     t_all_start = time.perf_counter()
 
     # plain, picklable args only -- never the zarr group itself
@@ -289,6 +294,7 @@ if __name__ == "__main__":
         for filename in images
     ]
 
+    done = 0
     with Pool(processes) as p:
 
         # imap (ordered) + main-as-sole-writer => deterministic, race-free writes
@@ -298,7 +304,9 @@ if __name__ == "__main__":
                 if filename not in zg[scale_group]:
                     zg[scale_group].create_dataset(filename, data=arr)
 
+            done += 1
             print(f"Time for conversion {filename}: {round(duration, 2)} s", flush=True)
+            print(f"@@PROGRESS@@ STEP {done} {total}", flush=True)
 
     print(f"All tasks completed: {round(time.perf_counter() - t_all_start, 2)} s", flush=True)
 

--- a/PyReconstruct/assets/scripts/start_process.py
+++ b/PyReconstruct/assets/scripts/start_process.py
@@ -1,8 +1,12 @@
 import sys
 import os
+import time
 from pathlib import Path
 
-from PySide6.QtWidgets import QApplication, QMainWindow, QPlainTextEdit, QVBoxLayout, QWidget, QLabel
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QPlainTextEdit, QVBoxLayout, QWidget, QLabel,
+    QProgressBar,
+)
 from PySide6.QtCore import QProcess
 
 
@@ -12,16 +16,27 @@ class MainWindow(QMainWindow):
         super().__init__()
 
         self.p = None
+        self._stdout_buf = ""        # buffers partial (unterminated) stdout lines
+        self._progress_start = None  # set when the first progress total arrives
 
         self.setWindowTitle("Zarr converter")
         self.setGeometry(100, 100, 600, 800)
+
+        self.heading = QLabel("Do not close this window until the process is done.", self)
+
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 0)  # indeterminate until a total is reported
+        self.progress.setTextVisible(True)
+
+        self.eta = QLabel("", self)
 
         self.text = QPlainTextEdit()
         self.text.setReadOnly(True)
 
         l = QVBoxLayout()
-        self.heading = QLabel("Do not close this window until the process is done.", self)
         l.addWidget(self.heading)
+        l.addWidget(self.progress)
+        l.addWidget(self.eta)
         l.addWidget(self.text)
 
         w = QWidget()
@@ -52,10 +67,61 @@ class MainWindow(QMainWindow):
         self.message(stderr)
 
     def handle_stdout(self):
-        
+
         data = self.p.readAllStandardOutput()
-        stdout = bytes(data).decode("utf8").strip()
-        self.message(stdout)
+        self._stdout_buf += bytes(data).decode("utf8", errors="replace")
+
+        # only act on complete lines; keep any trailing partial line buffered
+        *lines, self._stdout_buf = self._stdout_buf.split("\n")
+
+        for line in lines:
+            if line.startswith("@@PROGRESS@@"):
+                self.update_progress(line)
+            elif line.strip():
+                self.message(line)
+
+    def update_progress(self, line):
+        """Drive the progress bar / ETA from a converter progress marker.
+
+        Markers: '@@PROGRESS@@ TOTAL <n>' and '@@PROGRESS@@ STEP <done> <n>'.
+        """
+        parts = line.split()
+        if len(parts) < 3:
+            return
+
+        kind = parts[1]
+
+        if kind == "TOTAL":
+            total = int(parts[2])
+            self.progress.setRange(0, total)
+            self.progress.setValue(0)
+            self._progress_start = time.monotonic()
+            self.eta.setText(f"0 / {total} — estimating time remaining…")
+
+        elif kind == "STEP" and len(parts) >= 4:
+            done, total = int(parts[2]), int(parts[3])
+            if self.progress.maximum() != total:
+                self.progress.setRange(0, total)
+            self.progress.setValue(done)
+            self.eta.setText(self._eta_text(done, total))
+
+    def _eta_text(self, done, total):
+        if not self._progress_start or done <= 0:
+            return f"{done} / {total}"
+        elapsed = time.monotonic() - self._progress_start
+        remaining = (elapsed / done) * (total - done)
+        return f"{done} / {total} — ~{self._format_duration(remaining)} remaining"
+
+    @staticmethod
+    def _format_duration(seconds):
+        seconds = int(max(0, seconds))
+        hours, rem = divmod(seconds, 3600)
+        minutes, secs = divmod(rem, 60)
+        if hours:
+            return f"{hours}h {minutes:02d}m {secs:02d}s"
+        if minutes:
+            return f"{minutes}m {secs:02d}s"
+        return f"{secs}s"
         
     def handle_state(self, state):
         
@@ -67,22 +133,41 @@ class MainWindow(QMainWindow):
         state_name = states[state]
         #self.message(f"State changed: {state_name}")
 
-    def process_finished(self):
-        
-        self.message("Zarr processing finished.")
+    def process_finished(self, exit_code=0, exit_status=None):
 
-        if sys.platform == "linux":
+        # flush any trailing buffered output that lacked a newline
+        if self._stdout_buf.strip():
+            self.message(self._stdout_buf.strip())
+        self._stdout_buf = ""
 
-            self.message("Changing file permissions...")
+        if exit_code == 0:
 
-            zarr = sys.argv[3]
+            # show the bar as complete
+            if self.progress.maximum() == 0:  # was still indeterminate
+                self.progress.setRange(0, 1)
+            self.progress.setValue(self.progress.maximum())
+            self.eta.setText("Complete.")
 
-            os.system(f"find {zarr} -type d -exec chmod g+rwx {{}} +")
-            os.system(f"find {zarr} -type f -exec chmod g+rw {{}} +")
-        
-        self.message("You can close this window.")
-        self.heading.setText("Zarr processing done. You can safely close this window now.")
-        
+            self.message("Zarr processing finished.")
+
+            if sys.platform == "linux":
+
+                self.message("Changing file permissions...")
+
+                zarr = sys.argv[3]
+
+                os.system(f"find {zarr} -type d -exec chmod g+rwx {{}} +")
+                os.system(f"find {zarr} -type f -exec chmod g+rw {{}} +")
+
+            self.message("You can close this window.")
+            self.heading.setText("Zarr processing done. You can safely close this window now.")
+
+        else:
+
+            self.eta.setText("Stopped before completion.")
+            self.message(f"Zarr processing exited with code {exit_code}.")
+            self.heading.setText("Zarr processing did not finish — see messages above.")
+
         self.p = None
 
 


### PR DESCRIPTION
## Summary

The scaling conversion can run for a while, and the converter window previously showed only a scrolling text log. This adds a **progress bar and a live ETA** to that same window.

> **Stacked on #62** (`fix/zarr-scale-mp-hardening`). This PR's base is that branch, so the diff here is only the progress feature. Merge #62 first; GitHub will retarget this to `main` automatically.

## Changes

- **`zarree-2.py`** emits machine-readable progress markers from the (now sequential) main write loop:
  - `@@PROGRESS@@ TOTAL <n>` once, then `@@PROGRESS@@ STEP <done> <n>` after each image is written.
  - This is reliable precisely because the hardening PR made the main process the sole, ordered writer, so `done` reflects real persisted progress.
- **`start_process.py`** renders a `QProgressBar` + ETA label above the log:
  - stdout is now **line-buffered**, so a marker split across reads still parses correctly; marker lines drive the bar/ETA and are kept **out** of the text log.
  - ETA is derived from elapsed time per completed image (`elapsed/done × remaining`), shown as e.g. `120 / 480 — ~3m 20s remaining`.
  - The bar is **indeterminate** until a total arrives (covers the `create_ng_zarr` path, which emits no markers), shows **complete** on a clean exit, and reports **"did not finish"** with a non-zero exit code, so an early abort (e.g. the new disk-space check) is clearly surfaced rather than looking like success.

## Testing

- Confirmed the converter emits `@@PROGRESS@@ TOTAL n` then `STEP 1..n` in order (real run, update mode).
- Unit-tested the window's consumer logic (no display needed): line-buffering reassembles a marker split across two read chunks; markers are excluded from the log; ETA math checks out (50/200 in 30s → "1m 30s remaining"); duration formatting (`5s`, `1m 30s`, `1h 02m 05s`).
- Full GUI behavior should be eyeballed on a real run, but the parsing/ETA logic is covered.
