### PR TITLE
feat(gui): report and delete skipped malformed contours in a dialog

### DIFF
--- a/PyReconstruct/modules/calc/feret.py
+++ b/PyReconstruct/modules/calc/feret.py
@@ -66,6 +66,11 @@ of pairs of points touched by each pair of lines."""
 def feret(Points):
     """Given a list of 2d points, returns the minimum and maximum feret diameters."""
     sq_dist_pairs = [((p[0]-q[0])**2 + (p[1]-q[1])**2, (p,q)) for p, q in rotatingCalipers(Points)]
+    if not sq_dist_pairs:
+        # Degenerate point set (empty, a single point, or all points
+        # coincident) collapses the convex hull so rotatingCalipers yields
+        # nothing. Such a trace has no extent, so its feret diameters are 0.
+        return 0.0, 0.0
     min_feret_sq, _ = min(sq_dist_pairs)
     max_feret_sq, _ = max(sq_dist_pairs)
     return sqrt(min_feret_sq), sqrt(max_feret_sq)

--- a/PyReconstruct/modules/datatypes/points.py
+++ b/PyReconstruct/modules/datatypes/points.py
@@ -25,6 +25,14 @@ class Points:
     def __init__(self, points: PointSeq, closed: bool) -> None:
 
         self.points: PointSeq
+        self.closed: bool = closed
+
+        if not points:
+            # Nothing to normalize. This happens when interpolation produces
+            # no points (a degenerate, near-zero-length trace). Leave it empty
+            # so callers can detect that there is nothing to smooth.
+            self.points = []
+            return
 
         ends_match = points[0] == points[-1]
 
@@ -47,8 +55,6 @@ class Points:
             else:
 
                 self.points = points
-            
-        self.closed: bool = closed
 
     def __str__(self) -> str:
 

--- a/PyReconstruct/modules/datatypes/series.py
+++ b/PyReconstruct/modules/datatypes/series.py
@@ -1294,8 +1294,10 @@ class Series():
                 (list): one record per skipped trace, each a dict with keys
                     "name" (object name), "section" (section number),
                     "points" (point count), "location" ((x, y) of the first
-                    point, or None when the trace has no points) and "reason"
-                    (why it was skipped). Empty when nothing was skipped.
+                    point, or None when the trace has no points), "reason"
+                    (why it was skipped) and "match" (a {"color", "points"}
+                    signature used to re-find and delete the trace later).
+                    Empty when nothing was skipped.
         """
 
         window = self.getOption("roll_window")
@@ -1346,6 +1348,17 @@ class Series():
                                     if num_points < 3
                                     else "Smoothing produced no points"
                                 ),
+                                # signature used to re-find this exact trace at
+                                # delete time (sections are reloaded fresh from
+                                # disk). points are rounded to the 7 decimals
+                                # save() writes, so the match survives a reload.
+                                "match": {
+                                    "color": trace.color,
+                                    "points": [
+                                        (round(x, 7), round(y, 7))
+                                        for x, y in trace.points
+                                    ],
+                                },
                             })
 
                     if smoothed_any:
@@ -1357,7 +1370,74 @@ class Series():
             self.modified = True
 
         return malformed
-    
+
+    def deleteMalformedTraces(self, records : list, series_states=None) -> list:
+        """Delete specific malformed traces reported by smoothObject.
+
+        Each record must carry the keys produced by smoothObject — in
+        particular "name", "section" and "match" (a {"color", "points"}
+        signature). Because sections are reloaded fresh from disk, the stored
+        signature is matched against each candidate trace by color and
+        7-decimal-rounded points rather than by object identity, so the exact
+        trace is removed even across a save/reload. A record whose trace can no
+        longer be found (e.g. it was edited or re-smoothed in the meantime) is
+        skipped and left out of the returned list.
+
+            Params:
+                records (list): malformed-contour records to delete
+                series_states: the series states as stored in the GUI (undo)
+            Returns:
+                (list): the records whose trace was found and deleted
+        """
+        ## Group records by section so each section is loaded and saved once
+        by_section = {}
+        for record in records:
+            by_section.setdefault(record["section"], []).append(record)
+
+        if not by_section:
+            return []
+
+        deleted = []
+        for snum, section in self.enumerateSections(
+            message="Deleting malformed contours...",
+            series_states=series_states
+        ):
+            removed_any = False
+            for record in by_section.get(snum, []):
+                contour = section.contours.get(record["name"])
+                if not contour:
+                    continue
+                for trace in contour:
+                    if self._traceMatchesSignature(trace, record["match"]):
+                        section.removeTrace(trace)
+                        deleted.append(record)
+                        removed_any = True
+                        break
+            if removed_any:
+                section.save()
+
+        if deleted:
+            self.modified = True
+        return deleted
+
+    @staticmethod
+    def _traceMatchesSignature(trace, signature) -> bool:
+        """Whether a trace matches a malformed record's signature.
+
+        Compares color and points; points are rounded to 7 decimals (the
+        precision save() writes to disk) so a signature captured before save
+        still matches the trace once it is reloaded.
+        """
+        if trace.color != signature["color"]:
+            return False
+        points = trace.points
+        if len(points) != len(signature["points"]):
+            return False
+        for (x, y), (sx, sy) in zip(points, signature["points"]):
+            if round(x, 7) != sx or round(y, 7) != sy:
+                return False
+        return True
+
     def editObjectRadius(self, obj_names : list, new_rad : float, series_states=None):
         """Change the radii of all traces of an object.
         

--- a/PyReconstruct/modules/datatypes/series.py
+++ b/PyReconstruct/modules/datatypes/series.py
@@ -1284,15 +1284,18 @@ class Series():
         
         self.modified = True
 
-    def smoothObject(self, obj_names: list, series_states=None, log_event=True) -> dict:
+    def smoothObject(self, obj_names: list, series_states=None, log_event=True) -> list:
         """Smooth all traces belonging to an object.
 
         Malformed traces with too few points to smooth (e.g. "pixel dust"
         artifacts) are skipped rather than smoothed.
 
             Returns:
-                (dict): {obj_name: sorted list of section numbers} for contours
-                    that had one or more traces skipped for being malformed
+                (list): one record per skipped trace, each a dict with keys
+                    "name" (object name), "section" (section number),
+                    "points" (point count), "location" ((x, y) of the first
+                    point, or None when the trace has no points) and "reason"
+                    (why it was skipped). Empty when nothing was skipped.
         """
 
         window = self.getOption("roll_window")
@@ -1303,7 +1306,7 @@ class Series():
 
                 self.addLog(obj_name, None, f"Smooth {obj_name} traces")
 
-        malformed = {}
+        malformed = []
 
         for snum, section in self.enumerateSections(
                 message="Smoothing traces...",
@@ -1326,7 +1329,24 @@ class Series():
 
                         else:
 
-                            malformed.setdefault(obj_name, set()).add(snum)
+                            num_points = len(trace.points)
+
+                            malformed.append({
+                                "name": obj_name,
+                                "section": snum,
+                                "points": num_points,
+                                "location": (
+                                    tuple(round(c, 4) for c in trace.points[0])
+                                    if num_points else None
+                                ),
+                                # Trace.smooth only returns falsy for these two
+                                # reasons, distinguishable by the point count.
+                                "reason": (
+                                    "Fewer than 3 points"
+                                    if num_points < 3
+                                    else "Smoothing produced no points"
+                                ),
+                            })
 
                     if smoothed_any:
 
@@ -1336,7 +1356,7 @@ class Series():
 
             self.modified = True
 
-        return {name: sorted(snums) for name, snums in malformed.items()}
+        return malformed
     
     def editObjectRadius(self, obj_names : list, new_rad : float, series_states=None):
         """Change the radii of all traces of an object.

--- a/PyReconstruct/modules/datatypes/trace.py
+++ b/PyReconstruct/modules/datatypes/trace.py
@@ -583,6 +583,10 @@ class Trace():
 
             smoothed = smoothed[:-1]
 
+        if not smoothed:
+
+            return False
+
         self.points = smoothed
 
         return True

--- a/PyReconstruct/modules/gui/dialog/__init__.py
+++ b/PyReconstruct/modules/gui/dialog/__init__.py
@@ -19,3 +19,4 @@ from .shortcuts import ShortcutsDialog
 from .backup_comment import BackupCommentDialog
 from .table_columns import TableColumnsDialog
 from .import_series import ImportSeriesDialog
+from .malformed_contours import MalformedContoursDialog

--- a/PyReconstruct/modules/gui/dialog/malformed_contours.py
+++ b/PyReconstruct/modules/gui/dialog/malformed_contours.py
@@ -20,11 +20,11 @@ from PySide6.QtCore import Qt
 class MalformedContoursDialog(QDialog):
     """Report contours skipped during object smoothing for being malformed.
 
-    Each row is one trace that could not be smoothed (too few points to
-    interpolate -- often "pixel dust" left over from preprocessing the
-    .jser). The dialog shows enough context to track each one down: the
-    object, the section, how many points the trace had, where it sits, and
-    why it was skipped. Double-clicking a row focuses the field on it, and
+    Each row is one trace that could not be smoothed (typically too few
+    points to interpolate a curve). The dialog shows enough context to track
+    each one down: the object, the section, how many points the trace had,
+    where it sits, and why it was skipped. Selecting a row and clicking
+    "Go to contour" (or double-clicking the row) focuses the field on it, and
     the list can be copied or exported for triage.
     """
 
@@ -57,14 +57,15 @@ class MalformedContoursDialog(QDialog):
         trace_word = "trace" if num_traces == 1 else "traces"
         obj_word = "object" if num_objs == 1 else "objects"
         was_were = "was" if num_traces == 1 else "were"
-        they = "it" if num_traces == 1 else "they"
         heading = QLabel(
             f"{num_traces} contour {trace_word} across {num_objs} {obj_word} "
-            f"{was_were} skipped while smoothing because {they} could not be "
-            "smoothed. These are often \"pixel dust\" artifacts introduced "
-            "when the .jser was preprocessed; see the Reason column for each "
-            "trace. The malformed traces were left untouched.\n\n"
-            "Double-click a row to focus the field on it.",
+            f"{was_were} skipped while smoothing.\n\n"
+            "A trace is malformed when it cannot be smoothed — usually "
+            "because it has too few points to interpolate a curve (fewer "
+            "than 3). These traces were left unchanged; the Reason column "
+            "explains why each one was skipped.\n\n"
+            "Select a row and click “Go to contour” to focus the "
+            "field on that trace.",
             self,
         )
         heading.setWordWrap(True)
@@ -82,14 +83,31 @@ class MalformedContoursDialog(QDialog):
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.table.cellDoubleClicked.connect(self._onDoubleClick)
 
-        copy_button = QPushButton("Copy to clipboard", self)
+        self.goto_button = QPushButton("Go to contour", self)
+        self.goto_button.setToolTip(
+            "Focus the field on the selected contour"
+        )
+        self.goto_button.setEnabled(False)
+        self.goto_button.clicked.connect(self.goToSelectedContour)
+        # connected after the button exists so the slot can safely touch it
+        self.table.itemSelectionChanged.connect(self._updateGoToEnabled)
+
+        copy_button = QPushButton("Copy table list", self)
+        copy_button.setToolTip(
+            "Copy the table of malformed contours above to the clipboard "
+            "(tab-separated, including the column headers)"
+        )
         copy_button.clicked.connect(self.copyToClipboard)
 
-        save_button = QPushButton("Save as CSV…", self)
+        save_button = QPushButton("Save table as CSV…", self)
+        save_button.setToolTip(
+            "Save the table of malformed contours above to a CSV file"
+        )
         save_button.clicked.connect(self.saveCSV)
 
         buttonbox = QDialogButtonBox(QDialogButtonBox.Close, self)
         buttonbox.rejected.connect(self.reject)
+        buttonbox.addButton(self.goto_button, QDialogButtonBox.ActionRole)
         buttonbox.addButton(copy_button, QDialogButtonBox.ActionRole)
         buttonbox.addButton(save_button, QDialogButtonBox.ActionRole)
 
@@ -122,6 +140,9 @@ class MalformedContoursDialog(QDialog):
                 (name_item, section_item, points_item, loc_item, reason_item)
             ):
                 item.setTextAlignment(Qt.AlignCenter)
+                # show the full cell value on hover; columns are stretched to
+                # fit the window, so wider values (e.g. the Reason) truncate
+                item.setToolTip(item.text())
                 self.table.setItem(row, col, item)
 
     @staticmethod
@@ -131,15 +152,29 @@ class MalformedContoursDialog(QDialog):
             return "—"
         return f"({loc[0]}, {loc[1]})"
 
-    def _onDoubleClick(self, row, _col):
-        """Focus the field on the double-clicked contour."""
-        if not self.navigate:
+    def _updateGoToEnabled(self):
+        """Enable the Go-to button only while a row is selected."""
+        self.goto_button.setEnabled(self.table.selectionModel().hasSelection())
+
+    def _navigateToRow(self, row):
+        """Focus the field on the contour in the given table row."""
+        if not self.navigate or row < 0:
             return
         item = self.table.item(row, 0)
         if item is None:
             return
         section_num, obj_name = item.data(Qt.UserRole)
         self.navigate(section_num, obj_name)
+
+    def goToSelectedContour(self):
+        """Focus the field on the currently selected contour."""
+        rows = self.table.selectionModel().selectedRows()
+        if rows:
+            self._navigateToRow(rows[0].row())
+
+    def _onDoubleClick(self, row, _col):
+        """Focus the field on the double-clicked contour."""
+        self._navigateToRow(row)
 
     def _rows_for_export(self):
         """Return the report as a list of rows (header first).

--- a/PyReconstruct/modules/gui/dialog/malformed_contours.py
+++ b/PyReconstruct/modules/gui/dialog/malformed_contours.py
@@ -16,6 +16,8 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt
 
+from PyReconstruct.modules.gui.utils import notifyConfirm
+
 
 class MalformedContoursDialog(QDialog):
     """Report contours skipped during object smoothing for being malformed.
@@ -30,16 +32,21 @@ class MalformedContoursDialog(QDialog):
 
     COLUMNS = ["Object", "Section", "Point count", "Location (x, y)", "Reason"]
 
-    def __init__(self, mainwindow: QWidget, records: list, navigate=None):
+    def __init__(self, mainwindow: QWidget, records: list, navigate=None,
+                 delete=None):
         """Create the malformed-contours dialog.
 
             Params:
                 mainwindow (QWidget): the parent window
                 records (list): list of dicts, each with keys "name",
-                    "section", "points", "location" ((x, y) or None) and
-                    "reason"
+                    "section", "points", "location" ((x, y) or None), "reason"
+                    and "trace" (the Trace object, used for deletion)
                 navigate (callable): optional navigate(section_num, obj_name)
                     callback used to focus the field on a double-clicked row
+                delete (callable): optional delete(records) callback that
+                    removes the given records from the series and returns the
+                    records actually deleted; the Delete buttons are only shown
+                    when it is provided
         """
         super().__init__(mainwindow)
         # destroy (don't merely hide) on close so repeated runs don't leave
@@ -48,33 +55,19 @@ class MalformedContoursDialog(QDialog):
         self.mainwindow = mainwindow
         self.records = records
         self.navigate = navigate
+        self.delete = delete
 
         self.setWindowTitle("Malformed contours skipped while smoothing")
         self.resize(660, 420)
 
-        num_traces = len(records)
-        num_objs = len({r["name"] for r in records})
-        trace_word = "trace" if num_traces == 1 else "traces"
-        obj_word = "object" if num_objs == 1 else "objects"
-        was_were = "was" if num_traces == 1 else "were"
-        heading = QLabel(
-            f"{num_traces} contour {trace_word} across {num_objs} {obj_word} "
-            f"{was_were} skipped while smoothing.\n\n"
-            "A trace is malformed when it cannot be smoothed — usually "
-            "because it has too few points to interpolate a curve (fewer "
-            "than 3). These traces were left unchanged; the Reason column "
-            "explains why each one was skipped.\n\n"
-            "Select a row and click “Go to contour” to focus the "
-            "field on that trace.",
-            self,
-        )
-        heading.setWordWrap(True)
+        self.heading = QLabel(self._headingText(), self)
+        self.heading.setWordWrap(True)
 
-        self.table = QTableWidget(num_traces, len(self.COLUMNS), self)
+        self.table = QTableWidget(len(self.records), len(self.COLUMNS), self)
         self.table.setHorizontalHeaderLabels(self.COLUMNS)
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.table.verticalHeader().setVisible(False)
         self.table.setSortingEnabled(False)
         self._populate()
@@ -89,8 +82,6 @@ class MalformedContoursDialog(QDialog):
         )
         self.goto_button.setEnabled(False)
         self.goto_button.clicked.connect(self.goToSelectedContour)
-        # connected after the button exists so the slot can safely touch it
-        self.table.itemSelectionChanged.connect(self._updateGoToEnabled)
 
         copy_button = QPushButton("Copy table list", self)
         copy_button.setToolTip(
@@ -105,25 +96,94 @@ class MalformedContoursDialog(QDialog):
         )
         save_button.clicked.connect(self.saveCSV)
 
+        # destructive actions, only when a delete callback is provided
+        self.delete_selected_button = None
+        self.delete_all_button = None
+        if self.delete:
+            self.delete_selected_button = QPushButton("Delete selected", self)
+            self.delete_selected_button.setToolTip(
+                "Delete the selected contour(s) from the series (can be undone)"
+            )
+            self.delete_selected_button.setEnabled(False)
+            self.delete_selected_button.clicked.connect(
+                self.deleteSelectedContours
+            )
+
+            self.delete_all_button = QPushButton("Delete all", self)
+            self.delete_all_button.setToolTip(
+                "Delete every contour listed above from the series "
+                "(can be undone)"
+            )
+            self.delete_all_button.setEnabled(bool(self.records))
+            self.delete_all_button.clicked.connect(self.deleteAllContours)
+
+        # connected after the buttons exist so the slot can safely touch them
+        self.table.itemSelectionChanged.connect(self._updateRowActionButtons)
+
         buttonbox = QDialogButtonBox(QDialogButtonBox.Close, self)
         buttonbox.rejected.connect(self.reject)
         buttonbox.addButton(self.goto_button, QDialogButtonBox.ActionRole)
         buttonbox.addButton(copy_button, QDialogButtonBox.ActionRole)
         buttonbox.addButton(save_button, QDialogButtonBox.ActionRole)
+        if self.delete:
+            buttonbox.addButton(
+                self.delete_selected_button, QDialogButtonBox.ActionRole
+            )
+            buttonbox.addButton(
+                self.delete_all_button, QDialogButtonBox.ActionRole
+            )
 
         layout = QVBoxLayout()
-        layout.addWidget(heading)
+        layout.addWidget(self.heading)
         layout.addWidget(self.table)
         layout.addWidget(buttonbox)
         self.setLayout(layout)
 
+    def _headingText(self):
+        """Build the heading text from the current records."""
+        num_traces = len(self.records)
+        if not num_traces:
+            return (
+                "All listed malformed contours have been deleted.\n\n"
+                "You can close this window."
+            )
+
+        num_objs = len({r["name"] for r in self.records})
+        trace_word = "trace" if num_traces == 1 else "traces"
+        obj_word = "object" if num_objs == 1 else "objects"
+        was_were = "was" if num_traces == 1 else "were"
+
+        action = (
+            "Select one or more rows, then use “Go to contour” to focus the "
+            "field, or “Delete selected” / “Delete all” to remove them."
+            if self.delete
+            else "Select a row and click “Go to contour” to focus the field "
+            "on that trace."
+        )
+
+        return (
+            f"{num_traces} contour {trace_word} across {num_objs} {obj_word} "
+            f"{was_were} skipped while smoothing.\n\n"
+            "A trace is malformed when it cannot be smoothed — usually "
+            "because it has too few points to interpolate a curve (fewer "
+            "than 3). These traces were left unchanged; the Reason column "
+            "explains why each one was skipped.\n\n"
+            f"{action}"
+        )
+
     def _populate(self):
         """Fill the table from the records."""
+        # Qt may hand back a *copy* of a stored Python object, so identity
+        # through item data is unreliable. Stash a stable int key per row and
+        # resolve it back to the real record via this map; the key travels with
+        # the row through re-sorting.
+        self._records_by_key = {}
         for row, r in enumerate(self.records):
 
+            self._records_by_key[row] = r
+
             name_item = QTableWidgetItem(str(r["name"]))
-            # stash navigation target on the row so it survives re-sorting
-            name_item.setData(Qt.UserRole, (int(r["section"]), str(r["name"])))
+            name_item.setData(Qt.UserRole, row)
 
             section_item = QTableWidgetItem()
             section_item.setData(Qt.DisplayRole, int(r["section"]))
@@ -152,19 +212,30 @@ class MalformedContoursDialog(QDialog):
             return "—"
         return f"({loc[0]}, {loc[1]})"
 
-    def _updateGoToEnabled(self):
-        """Enable the Go-to button only while a row is selected."""
-        self.goto_button.setEnabled(self.table.selectionModel().hasSelection())
+    def _updateRowActionButtons(self):
+        """Enable selection-dependent buttons only while a row is selected."""
+        has_selection = self.table.selectionModel().hasSelection()
+        self.goto_button.setEnabled(has_selection)
+        if self.delete_selected_button is not None:
+            self.delete_selected_button.setEnabled(has_selection)
+
+    def _recordAtRow(self, row):
+        """Return the record for the given table row (or None)."""
+        if row < 0:
+            return None
+        item = self.table.item(row, 0)
+        if item is None:
+            return None
+        return self._records_by_key.get(item.data(Qt.UserRole))
 
     def _navigateToRow(self, row):
         """Focus the field on the contour in the given table row."""
-        if not self.navigate or row < 0:
+        if not self.navigate:
             return
-        item = self.table.item(row, 0)
-        if item is None:
+        record = self._recordAtRow(row)
+        if record is None:
             return
-        section_num, obj_name = item.data(Qt.UserRole)
-        self.navigate(section_num, obj_name)
+        self.navigate(record["section"], record["name"])
 
     def goToSelectedContour(self):
         """Focus the field on the currently selected contour."""
@@ -175,6 +246,59 @@ class MalformedContoursDialog(QDialog):
     def _onDoubleClick(self, row, _col):
         """Focus the field on the double-clicked contour."""
         self._navigateToRow(row)
+
+    def _selectedRecords(self):
+        """Return the records for the currently selected rows."""
+        records = []
+        for index in self.table.selectionModel().selectedRows():
+            record = self._recordAtRow(index.row())
+            if record is not None:
+                records.append(record)
+        return records
+
+    def deleteSelectedContours(self):
+        """Delete the contours for the currently selected rows."""
+        self._deleteRecords(self._selectedRecords())
+
+    def deleteAllContours(self):
+        """Delete every contour listed in the dialog."""
+        self._deleteRecords(list(self.records))
+
+    def _deleteRecords(self, records):
+        """Confirm, delete the given records, and prune the rows that went."""
+        if not self.delete or not records:
+            return
+        count = len(records)
+        noun = "contour" if count == 1 else "contours"
+        if not notifyConfirm(
+            f"Delete {count} malformed {noun} from the series?\n\n"
+            "This can be undone (Ctrl+Z).",
+            yn=True,
+        ):
+            return
+        deleted = self.delete(records)
+        self._pruneRecords(deleted or [])
+
+    def _pruneRecords(self, deleted):
+        """Remove the rows/records that were actually deleted."""
+        if not deleted:
+            return
+        deleted_ids = {id(r) for r in deleted}
+        # remove bottom-up so earlier row indices stay valid
+        for row in range(self.table.rowCount() - 1, -1, -1):
+            item = self.table.item(row, 0)
+            if item is None:
+                continue
+            key = item.data(Qt.UserRole)
+            record = self._records_by_key.get(key)
+            if record is not None and id(record) in deleted_ids:
+                self.table.removeRow(row)
+                del self._records_by_key[key]
+        self.records = list(self._records_by_key.values())
+        self.heading.setText(self._headingText())
+        if self.delete_all_button is not None:
+            self.delete_all_button.setEnabled(bool(self.records))
+        self._updateRowActionButtons()
 
     def _rows_for_export(self):
         """Return the report as a list of rows (header first).

--- a/PyReconstruct/modules/gui/dialog/malformed_contours.py
+++ b/PyReconstruct/modules/gui/dialog/malformed_contours.py
@@ -1,0 +1,176 @@
+import csv
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QDialog,
+    QLabel,
+    QVBoxLayout,
+    QTableWidget,
+    QTableWidgetItem,
+    QPushButton,
+    QDialogButtonBox,
+    QHeaderView,
+    QAbstractItemView,
+    QApplication,
+    QFileDialog,
+)
+from PySide6.QtCore import Qt
+
+
+class MalformedContoursDialog(QDialog):
+    """Report contours skipped during object smoothing for being malformed.
+
+    Each row is one trace that could not be smoothed (too few points to
+    interpolate -- often "pixel dust" left over from preprocessing the
+    .jser). The dialog shows enough context to track each one down: the
+    object, the section, how many points the trace had, where it sits, and
+    why it was skipped. Double-clicking a row focuses the field on it, and
+    the list can be copied or exported for triage.
+    """
+
+    COLUMNS = ["Object", "Section", "Point count", "Location (x, y)", "Reason"]
+
+    def __init__(self, mainwindow: QWidget, records: list, navigate=None):
+        """Create the malformed-contours dialog.
+
+            Params:
+                mainwindow (QWidget): the parent window
+                records (list): list of dicts, each with keys "name",
+                    "section", "points", "location" ((x, y) or None) and
+                    "reason"
+                navigate (callable): optional navigate(section_num, obj_name)
+                    callback used to focus the field on a double-clicked row
+        """
+        super().__init__(mainwindow)
+        # destroy (don't merely hide) on close so repeated runs don't leave
+        # hidden dialog children parented to the main window
+        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.mainwindow = mainwindow
+        self.records = records
+        self.navigate = navigate
+
+        self.setWindowTitle("Malformed contours skipped while smoothing")
+        self.resize(660, 420)
+
+        num_traces = len(records)
+        num_objs = len({r["name"] for r in records})
+        trace_word = "trace" if num_traces == 1 else "traces"
+        obj_word = "object" if num_objs == 1 else "objects"
+        was_were = "was" if num_traces == 1 else "were"
+        they = "it" if num_traces == 1 else "they"
+        heading = QLabel(
+            f"{num_traces} contour {trace_word} across {num_objs} {obj_word} "
+            f"{was_were} skipped while smoothing because {they} could not be "
+            "smoothed. These are often \"pixel dust\" artifacts introduced "
+            "when the .jser was preprocessed; see the Reason column for each "
+            "trace. The malformed traces were left untouched.\n\n"
+            "Double-click a row to focus the field on it.",
+            self,
+        )
+        heading.setWordWrap(True)
+
+        self.table = QTableWidget(num_traces, len(self.COLUMNS), self)
+        self.table.setHorizontalHeaderLabels(self.COLUMNS)
+        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSortingEnabled(False)
+        self._populate()
+        self.table.setSortingEnabled(True)
+        self.table.sortItems(1)  # default sort by section number
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.cellDoubleClicked.connect(self._onDoubleClick)
+
+        copy_button = QPushButton("Copy to clipboard", self)
+        copy_button.clicked.connect(self.copyToClipboard)
+
+        save_button = QPushButton("Save as CSV…", self)
+        save_button.clicked.connect(self.saveCSV)
+
+        buttonbox = QDialogButtonBox(QDialogButtonBox.Close, self)
+        buttonbox.rejected.connect(self.reject)
+        buttonbox.addButton(copy_button, QDialogButtonBox.ActionRole)
+        buttonbox.addButton(save_button, QDialogButtonBox.ActionRole)
+
+        layout = QVBoxLayout()
+        layout.addWidget(heading)
+        layout.addWidget(self.table)
+        layout.addWidget(buttonbox)
+        self.setLayout(layout)
+
+    def _populate(self):
+        """Fill the table from the records."""
+        for row, r in enumerate(self.records):
+
+            name_item = QTableWidgetItem(str(r["name"]))
+            # stash navigation target on the row so it survives re-sorting
+            name_item.setData(Qt.UserRole, (int(r["section"]), str(r["name"])))
+
+            section_item = QTableWidgetItem()
+            section_item.setData(Qt.DisplayRole, int(r["section"]))
+
+            points_item = QTableWidgetItem()
+            points_item.setData(Qt.DisplayRole, int(r["points"]))
+
+            loc = r.get("location")
+            loc_item = QTableWidgetItem(self._format_location(loc))
+
+            reason_item = QTableWidgetItem(str(r["reason"]))
+
+            for col, item in enumerate(
+                (name_item, section_item, points_item, loc_item, reason_item)
+            ):
+                item.setTextAlignment(Qt.AlignCenter)
+                self.table.setItem(row, col, item)
+
+    @staticmethod
+    def _format_location(loc):
+        """Render a location tuple for display ('—' when there are no points)."""
+        if not loc:
+            return "—"
+        return f"({loc[0]}, {loc[1]})"
+
+    def _onDoubleClick(self, row, _col):
+        """Focus the field on the double-clicked contour."""
+        if not self.navigate:
+            return
+        item = self.table.item(row, 0)
+        if item is None:
+            return
+        section_num, obj_name = item.data(Qt.UserRole)
+        self.navigate(section_num, obj_name)
+
+    def _rows_for_export(self):
+        """Return the report as a list of rows (header first).
+
+        Reads the table in its current visual order so the export matches what
+        the user sees, including any column sort they have applied.
+        """
+        rows = [list(self.COLUMNS)]
+        for row in range(self.table.rowCount()):
+            cells = []
+            for col in range(self.table.columnCount()):
+                item = self.table.item(row, col)
+                cells.append("" if item is None else item.text())
+            rows.append(cells)
+        return rows
+
+    def copyToClipboard(self):
+        """Copy the report to the clipboard as tab-separated text."""
+        rows = self._rows_for_export()
+        text = "\n".join("\t".join(cell for cell in row) for row in rows)
+        QApplication.clipboard().setText(text)
+
+    def saveCSV(self):
+        """Save the report to a CSV file the user chooses."""
+        fp, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save malformed contours",
+            "malformed_contours.csv",
+            "CSV files (*.csv);;All files (*)",
+        )
+        if not fp:
+            return
+        with open(fp, "w", newline="") as f:
+            csv.writer(f).writerows(self._rows_for_export())

--- a/PyReconstruct/modules/gui/main/field_widget_3_object.py
+++ b/PyReconstruct/modules/gui/main/field_widget_3_object.py
@@ -11,6 +11,7 @@ from PyReconstruct.modules.gui.dialog import (
     TraceDialog,
     ShapesDialog,
     ObjectGroupDialog,
+    MalformedContoursDialog,
 )
 from PyReconstruct.modules.gui.popup import (
     TextWidget,
@@ -179,13 +180,23 @@ class FieldWidgetObject(FieldWidgetTrace):
 
         if malformed:
 
-            names = ", ".join(sorted(malformed))
-            notify(
-                "Some contours were skipped because they were malformed "
-                f"(too few points to smooth): {names}"
+            # surface the skipped contours in a dialog with enough detail to
+            # track them down; double-clicking a row focuses the field on it
+            self.malformed_contours_dialog = MalformedContoursDialog(
+                self.mainwindow,
+                malformed,
+                navigate=self.focusMalformedContour,
             )
+            self.malformed_contours_dialog.show()
 
         return True
+
+    def focusMalformedContour(self, section_num: int, obj_name: str):
+        """Focus the field on a contour reported in the malformed dialog."""
+
+        # route through the canonical navigation path so an in-progress trace
+        # is finalized and field data is saved before the section switch
+        self.mainwindow.setToObject(obj_name, section_num)
     
     @object_function(update_objects=True, reload_field=False)
     def editComment(self, obj_names : list):

--- a/PyReconstruct/modules/gui/main/field_widget_3_object.py
+++ b/PyReconstruct/modules/gui/main/field_widget_3_object.py
@@ -186,6 +186,7 @@ class FieldWidgetObject(FieldWidgetTrace):
                 self.mainwindow,
                 malformed,
                 navigate=self.focusMalformedContour,
+                delete=self.deleteMalformedContours,
             )
             self.malformed_contours_dialog.show()
 
@@ -197,6 +198,50 @@ class FieldWidgetObject(FieldWidgetTrace):
         # route through the canonical navigation path so an in-progress trace
         # is finalized and field data is saved before the section switch
         self.mainwindow.setToObject(obj_name, section_num)
+
+    def deleteMalformedContours(self, records: list) -> list:
+        """Delete malformed contours chosen in the dialog.
+
+        Mirrors the object-list delete/reload path: refuse locked objects, save
+        field data, delete via the series (whose enumerateSections records the
+        undo state), then refresh the tables and field. Returns the records
+        actually deleted so the dialog can prune exactly those rows.
+        """
+        if not records:
+            return []
+
+        # like the object_function delete path, never modify locked objects
+        names = {r["name"] for r in records}
+        if any(self.series.getAttr(n, "locked") for n in names):
+            notify(
+                "Cannot delete contours of locked objects.\n"
+                "Please unlock before deleting."
+            )
+            return []
+
+        # persist field edits to section data before reloading sections
+        self.mainwindow.saveAllData()
+
+        deleted = self.series.deleteMalformedTraces(
+            records,
+            series_states=self.series_states,
+        )
+
+        if deleted:
+            self.table_manager.updateObjects({r["name"] for r in deleted})
+            self.reload()
+            self.mainwindow.seriesModified(True)
+
+        missed = len(records) - len(deleted)
+        if missed:
+            were = "was" if missed == 1 else "were"
+            notify(
+                f"{missed} of {len(records)} listed contour(s) {were} not "
+                "found and could not be deleted — they may have been changed "
+                "or removed since smoothing."
+            )
+
+        return deleted
     
     @object_function(update_objects=True, reload_field=False)
     def editComment(self, obj_names : list):


### PR DESCRIPTION
## Summary

Builds on the malformed-contour skipping from #60. When **Smooth object traces** skips malformed contours, instead of a one-line notification it now opens a dedicated dialog with enough detail to track each artifact down and to **act on them**: navigate to a contour, or delete individual / selected / all of them in place. Plus fixes for two crashes that degenerate traces caused along the way.

### Dialog
A sortable table with one row per skipped trace:

| Column | Meaning |
|---|---|
| Object | object the trace belongs to |
| Section | section it's on |
| Point count | how degenerate the trace is |
| Location (x, y) | first-point coordinates to locate it |
| Reason | why it was skipped (too few points / smoothing produced no points) |

- **Go to contour** button (or double-click a row) focuses the field on that contour, routed through `MainWindow.setToObject` so an in-progress trace is finalized and field data saved first.
- **Copy table list** / **Save table as CSV** export the list in the displayed (sorted) order, for triage outside the app.
- Every cell has a hover tooltip showing its full value, so truncated entries (e.g. a long Reason) are readable without resizing.
- `Series.smoothObject` now returns one record per skipped trace instead of `{obj_name: [sections]}` (single internal caller updated).

### Deleting from the list
The dialog is now actionable, so users can clean up pixel-dust / degenerate artifacts without hunting each one down:

- The table is multi-select; **Delete selected** removes the highlighted rows and **Delete all** removes everything listed. Action buttons (not a context menu) match the convention used by other dialogs.
- Deletion is confirmed first and is **undoable** (Ctrl+Z) through the same `series_states` stack as smoothing.
- `Series.smoothObject` records a `{color, points}` signature per skipped trace; the new `Series.deleteMalformedTraces` re-matches traces by that signature (points rounded to the 7 decimals `save()` writes) rather than by object identity, since sections are reloaded fresh from disk. Records whose trace can no longer be found (edited / re-smoothed since) are skipped and reported back, and only the rows actually removed are pruned from the table.
- The field-widget callback refuses locked objects, mirroring the object-list delete path, and refreshes the field + object list afterward.

### Crash fixes for degenerate traces
Skipping a malformed trace leaves it in place, which exposed two geometry routines that could not handle such traces:

- `Points.__init__` indexed `points[0]` before checking for an empty list, so a trace whose interpolation produced no points (≥3 nearly-coincident points, total length below the interpolation spacing) raised `IndexError`. It now returns an empty `Points`, which `Trace.smooth` already treats as nothing to smooth.
- `feret()` called `min()`/`max()` on an empty sequence when the convex hull collapsed to a single point (all points coincident), raising during `section.save()`. It now returns `(0, 0)` for a degenerate point set, which has no extent.
- `Trace.smooth` also guards against an empty result after the end-point trim.

## A note on the dialog wording
**The dialog text (heading, button labels, tooltips, reason strings) is intentionally open for revision.** The goal was a generic, clear explanation of what a malformed trace is without over-specifying the cause.

## Known follow-ups
- `deleteMalformedTraces` scans all sections (same as the existing `deleteAllTraces` on this branch); it can adopt the section-scoped iteration from the perf/large-jser work once that lands.
- The dialog is a modeless snapshot: after a delete-then-undo the list still shows the rows as removed until the dialog is reopened.

## Testing
Verified against a real series: smoothing an object with malformed contours completes without crashing, leaves the degenerate traces in place, and lists them in the dialog (with working navigation, export, and tooltips). The interpolation/feret fixes were reproduced and confirmed in isolation across empty / single-point / coincident-point inputs.

The delete path is covered by headless tests against a real on-disk series: signature matching across a save/reload, identical-duplicate handling (deleting one leaves exactly one), cross-section deletion, and partial deletion when a signature no longer matches; plus a widget test of the dialog (multi-select, delete selected/all, row pruning, button enable/disable, navigation).
