### PR TITLE
chore: remove stale .gitmodules submodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vijay"]
-	path = src/modules/backend/autoseg/vijay
-	url = https://github.com/yajivunev/autoseg


### PR DESCRIPTION
The "vijay" submodule at `src/modules/backend/autoseg/vijay` was added in May 2023, when the project used a `src/` layout. Since then the tree was restructured (`src/` dropped, code moved under `PyReconstruct/`) and the autoseg functionality was vendored as regular files (`PyReconstruct/modules/backend/autoseg/{__init__,conversions}.py`).

The gitlink was dropped during the restructure but the `.gitmodules` entry was left behind, so it now points at a path that no longer exists. `git submodule update --init` creates `src/modules/backend/ autoseg/vijay`, which does not correspond to anything in the tree.

There is no remaining gitlink or registered submodule to reference, so the entry is removed. This is the only entry in `.gitmodules`, so the file is deleted.

Closes #69 