### PR TITLE
build(packaging): add cross-platform PyInstaller installers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,16 @@ PyReconstruct
 
 To install a dev version of PyReconstruct, see [here](https://github.com/SynapseWeb/PyReconstruct/wiki/Developers).
 
+# Install with an installer (no command line)
+
+Prefer to install PyReconstruct like a normal desktop app? Grab an installer for your operating system from the [Releases page](https://github.com/SynapseWeb/PyReconstruct/releases). No Python or command line needed, and everything the app requires is bundled in.
+
+- **Windows.** Download the `.exe` and run it. The first time, Windows may warn that it "protected your PC" because the app isn't code-signed yet; click **More info**, then **Run anyway**.
+- **macOS.** Download the `.dmg`, open it, and drag PyReconstruct into your Applications folder. Because the app isn't signed yet, the first launch takes one extra step; the disk image includes a short **"Read Before First Launch"** note that walks you through it.
+- **Linux.** Download the `.sh` installer and run it. It adds PyReconstruct to your applications menu.
+
+*(Code signing, which removes those first-launch warnings, is on the way.)*
+
 # Bug reports / Feature requests
 
 If you notice a problem, would like to suggest a feature, or have ideas on improving our documentation, please [submit an issue](https://github.com/SynapseWeb/PyReconstruct/issues/). We appreciate the help!


### PR DESCRIPTION
Adds the machinery to build unsigned one-click desktop installers with PyInstaller, plus the freeze-safety fixes the app needs to run frozen. Deliberately decoupled from the in-app updater (that ships as a separate future PR, and no updater code is included here).

## Packaging
- PyInstaller one-folder spec (VTK/vedo, scipy, scikit-image, cloud-volume codecs, certifi, and a Windows software-GL/Mesa fallback for RDP/GPU-less machines).
- Runtime hooks: windowed stdio, Qt plugin-path reset, certifi CA bundle for TLS (cloud-volume / HTTPS / git over TLS), Windows software-GL preload.
- Windows installer (Inno Setup), macOS .dmg + .icns scripts with an unsigned first-launch (Gatekeeper) help file, and a self-contained Linux .sh installer with uninstaller and .desktop entry.
- build-installers.yml: builds Windows x86_64, macOS arm64, and macOS x86_64 natively; publishes a GitHub Release on a version tag and assembles the Linux asset. Installs latest main by default.
- pyproject.toml with setuptools-scm so the frozen app carries its version; replaces setup.py. requirements.txt is unchanged.
- Icons use the existing assets (Windows .ico; logo.png for macOS/Linux). The new logo is intentionally left out and deferred to a separate branding PR.

> Note on the default install source: this installs the latest `main` for now. Per an upcoming release-strategy proposal, the default will move to the latest tagged stable release, with latest-`main` kept as an opt-in channel. Tracked separately.

## Freeze-safety (source behavior unchanged)
- multiprocessing.freeze_support, a __run_script__ dispatcher for bundled helper scripts, a --selftest flag.
- constants/frozen.py (is_frozen / bundle_base / script_launch_prefix).
- Frozen-aware asset and version resolution (bundle or setuptools-scm); lazy gitpython import.
- cli.py: the source-only update path is guarded when frozen and directs users to re-download the latest installer from GitHub Releases.

## Verification
- py_compile + imports-only smoke test pass on Linux; workflow YAML parses; diff is installer-only.

Reviewer: Michael

Closes #68
