### PR TITLE
docs: add governance and onboarding files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 # https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repository.
-# Michael Chirillo and Julian Falco.
-* @quasiTriestino @julian-falco
+# Michael Chirillo.
+* @quasiTriestino

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS for PyReconstruct
+#
+# Code owners are automatically requested for review when a pull request
+# changes matching files. See:
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repository.
+# Michael Chirillo and Julian Falco.
+* @quasiTriestino @julian-falco

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+Thanks for contributing to PyReconstruct!
+
+Keep each pull request focused on a single logical change. PRs are
+squash-merged, so the PR title becomes the squashed commit subject — please
+write it as a Conventional Commit header, for example:
+
+  feat(gui): add trace palette redocking
+  fix(align): reject fewer than three matched traces
+  docs: expand developer setup guide
+
+See CONTRIBUTING.md for the full workflow.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Related issues
+
+<!-- e.g. "Closes #123", or "n/a". -->
+
+## Checklist
+
+- [ ] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) header.
+- [ ] This PR is a single, focused change.
+- [ ] The branch is named `type/slug` (e.g. `feat/…`, `fix/…`, `docs/…`).
+- [ ] I ran the app from a checkout and verified the change behaves as intended.
+- [ ] Documentation is updated where relevant (README, wiki, in-app help).
+- [ ] Commits avoid automated co-author / attribution trailers.
+
+## Reviewer
+
+<!-- Request a maintainer as reviewer (see CODEOWNERS). -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to PyReconstruct are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
+[semantic versioning](https://semver.org/).
+
+Entries under [Unreleased] have landed on `main` but are not yet part of a
+tagged release.
+
+## [Unreleased]
+
+## [1.20.0] - 2026-06-30
+
+Introducing PyReconstruct, a fully open-source, collaborative successor to
+_Reconstruct_, described in [*PNAS* (2025)](https://doi.org/10.1073/pnas.2505822122).
+
+[Unreleased]: https://github.com/SynapseWeb/PyReconstruct/compare/v1.20.0...HEAD
+[1.20.0]: https://github.com/SynapseWeb/PyReconstruct/releases/tag/v1.20.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ project's [GPL-3.0-or-later](license.md) license.
 ## Filing issues
 
 Open issues on the project's
-**[GitHub Issues](https://github.com/SynapseWeb/PyReconstruct/issues)**. Three
+**[GitHub Issues](https://github.com/SynapseWeb/PyReconstruct/issues)**. Four
 issue templates are available from the "New issue" chooser:
 
 - **Bug report** — please include the **version or commit** you're running.
@@ -26,6 +26,8 @@ issue templates are available from the "New issue" chooser:
 - **Feature request** — describe the problem you're trying to solve, not only a
   proposed solution.
 - **Documentation request** — tell us what's missing or unclear.
+- **Chore or task** — mainly for the development team's own tracking of
+  tooling, CI, and maintenance work, rather than typical outside requests.
 
 Documentation, an installation guide, and manuals are hosted on the lab's
 [wiki site](https://wikis.utexas.edu/display/khlab/PyReconstruct+user+guide) and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,182 @@
+# Contributing to PyReconstruct
+
+Thanks for your interest in improving PyReconstruct! PyReconstruct is developed
+and maintained in the [Kristen Harris Lab](https://synapseweb.clm.utexas.edu/)
+at **The University of Texas at Austin**. Contributions of bug reports, fixes,
+features, docs, and screenshots are all welcome.
+
+- **Found a bug or have an idea?** [Open an issue](#filing-issues).
+- **Want to write code or docs?** See [development setup](#development-setup)
+  and [branch and commit conventions](#branch-and-commit-conventions).
+
+By contributing, you agree that your contributions are licensed under the
+project's [GPL-3.0-or-later](license.md) license.
+
+---
+
+## Filing issues
+
+Open issues on the project's
+**[GitHub Issues](https://github.com/SynapseWeb/PyReconstruct/issues)**. Three
+issue templates are available from the "New issue" chooser:
+
+- **Bug report** — please include the **version or commit** you're running.
+  Find it in the app's **Help** menu, along with your OS, Python version, steps
+  to reproduce, and any console error output.
+- **Feature request** — describe the problem you're trying to solve, not only a
+  proposed solution.
+- **Documentation request** — tell us what's missing or unclear.
+
+Documentation, an installation guide, and manuals are hosted on the lab's
+[wiki site](https://wikis.utexas.edu/display/khlab/PyReconstruct+user+guide) and
+the [repository wiki](https://github.com/SynapseWeb/PyReconstruct/wiki).
+
+---
+
+## Development setup
+
+PyReconstruct targets **Python 3.11** and **PySide6**.
+
+### Conda environment
+
+The developer workflow uses a conda environment created by the `Makefile` in
+`dev/`:
+
+```bash
+cd dev
+make env              # create the `pyrecon_dev` conda env and link the source tree
+conda activate pyrecon_dev
+```
+
+`make env` creates the environment from `dev/environment_dev.yaml` (Python 3.11
+plus the runtime dependencies from `requirements.txt`) and runs
+`dev/link_shell.sh`, which puts the repository root on the environment's import
+path (so the source checkout is importable without installing) and registers the
+helper scripts in `dev/scripts/` on `PATH`.
+
+Other `Makefile` targets (run from `dev/`):
+
+| Command | What it does |
+|---|---|
+| `make help` | Show the available commands (the default target) |
+| `make env` | Create the `pyrecon_dev` environment and link the source tree |
+| `make update` | Update the environment from `environment_dev.yaml` (`--prune`) |
+| `make clean` | Remove the `pyrecon_dev` environment (alias: `make remove`) |
+
+You can change the environment name by editing `ENV_NAME` in `dev/Makefile`.
+See the [Developers](https://github.com/SynapseWeb/PyReconstruct/wiki/Developers)
+wiki page for more.
+
+### Running the app from a checkout
+
+In the activated environment, run the app from the repository root:
+
+```bash
+python PyReconstruct/run.py
+```
+
+Alternatively, `pip install -e .` installs the package in editable mode and
+provides the `PyReconstruct` console command (the entry point declared in
+`setup.py`, `PyReconstruct.cli:main`).
+
+---
+
+## Project layout
+
+PyReconstruct is a PySide6 desktop app. The Python package is `PyReconstruct/`:
+
+```
+PyReconstruct/
+├── run.py                  # Qt bootstrap and launch
+├── cli.py                  # `PyReconstruct` console entry point
+└── modules/
+    ├── backend/            # non-GUI logic, grouped by concern
+    │   ├── view/           #   field rendering layers (image, section, trace, zarr)
+    │   ├── volume/         #   3D mesh generation and export
+    │   ├── table/          #   data-list/table manager
+    │   ├── func/           #   transforms, imports, undo/redo state, conversions
+    │   ├── imports/        #   ImageJ ROI and other imports
+    │   ├── exports/        #   SVG / ROI export
+    │   ├── autoseg/        #   auto-segmentation conversions
+    │   ├── remote/         #   remote/example-data access
+    │   └── threading/      #   QThreadPool worker helpers
+    ├── gui/                # Qt / PySide6 UI
+    │   ├── main/           #   main window, menubar, field-widget mixins, context menus
+    │   ├── dialog/         #   dialogs (options, alignment, trace, grid, flag, …)
+    │   ├── palette/        #   floating tool/trace palettes and overlays
+    │   ├── popup/          #   3D scene window, about, help
+    │   ├── table/          #   the list/table widgets (object, trace, section, ztrace, flag, history)
+    │   └── utils/          #   UI helpers (notifications, progress bars, colors)
+    ├── datatypes/          # core domain model (Series, Section, Trace, Transform, Ztrace, Flag, …)
+    ├── datatypes_legacy/   # readers/writers for the legacy Reconstruct XML format
+    ├── calc/               # pure numeric/geometry (quantification, polygon, Feret, …)
+    ├── constants/          # constants and small helpers (paths, repo info, websites)
+    └── assets/             # bundled data (icons/cursors, welcome series, test fixtures)
+```
+
+Top-level directories outside the package:
+
+- `dev/` — developer tooling (`Makefile`, `environment_dev.yaml`,
+  `link_shell.sh`, helper `scripts/`).
+- `launch/` — clone-and-run scripts for end users.
+- `manual/` — the user manual.
+- `.github/` — issue and pull-request templates.
+
+Where it's practical, keep computation and data-model logic in `backend/`,
+`datatypes/`, and `calc/` (GUI-free and testable), and keep `gui/` focused on
+presentation.
+
+---
+
+## Branch and commit conventions
+
+This repository follows a lightweight, conventional workflow.
+
+### Branches
+
+Create feature branches on this repository using short `type/slug` names, where
+`type` matches the change:
+
+```
+feat/…   fix/…   docs/…   perf/…   refactor/…   test/…   build/…   ci/…   chore/…
+```
+
+For example: `feat/ui-theme`, `fix/knife-small-piece`, `docs/guides`.
+
+### Commits
+
+Write commit messages as [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(optional-scope): short summary in the imperative mood
+
+Optional body explaining what and why.
+```
+
+Keep messages **measured and factual** — describe the change and its rationale;
+avoid hyperbole. Please don't add automated co-author or attribution trailers
+(for example, trailers crediting AI assistants) to commits or pull requests.
+
+### Pull requests
+
+- Open pull requests **against this repository**
+  (`SynapseWeb/PyReconstruct`, `main` branch).
+- Keep a PR focused on **one logical change**.
+- A maintainer reviews each PR before it is merged.
+- PRs are **squash-merged**, so the **PR title becomes the squashed commit
+  subject** — write the PR title as a Conventional Commit header. The merged
+  commit keeps the `(#N)` PR reference.
+- Verify your change by running the app from a checkout, and add tests for
+  fixes and behavioral changes where practical.
+
+---
+
+## Credits and license
+
+PyReconstruct was created in the Kristen Harris Lab at **The University of Texas
+at Austin** (Michael A. Chirillo, Julian N. Falco, Michael D. Musslewhite,
+Larry F. Lindsey, and Kristen M. Harris) and introduced in
+[*PNAS* (2025)](https://doi.org/10.1073/pnas.2505822122). See the
+[readme](readme.md) for full citation details.
+
+PyReconstruct is licensed under [GPL-3.0-or-later](license.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+PyReconstruct is a desktop application developed and maintained in the Kristen
+Harris Lab at the University of Texas at Austin. We take security reports
+seriously and appreciate your help in keeping users safe.
+
+## Supported versions
+
+Security fixes are applied to the latest release and to the current `main`
+branch. Older releases are not maintained; please update before reporting an
+issue you believe is already fixed.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately using one of the following:
+
+- **GitHub private vulnerability reporting** — use the **"Report a
+  vulnerability"** button under this repository's
+  [Security tab](https://github.com/SynapseWeb/PyReconstruct/security/advisories),
+  if enabled.
+- **Email** — contact a maintainer directly:
+  - Michael Chirillo: michael.chirillo@uri.edu
+  - Dusten Hubbard: dusten@utexas.edu
+
+Please include enough detail to reproduce the issue: the version or commit
+affected, your operating system and Python version, and clear reproduction
+steps or a proof of concept.
+
+## What to expect
+
+- We aim to acknowledge a report within a week.
+- We will investigate, keep you informed of progress, and credit you in the
+  fix (with your permission) unless you prefer to remain anonymous.
+- Please give us a reasonable opportunity to release a fix before any public
+  disclosure.
+
+Thank you for helping keep PyReconstruct and its users safe.


### PR DESCRIPTION
Adds standard governance and onboarding documentation to the repository:

- `.github/CODEOWNERS` (default code owners @quasiTriestino, @julian-falco)
- `.github/PULL_REQUEST_TEMPLATE.md` (PR checklist template)
- `CONTRIBUTING.md` (contributor onboarding guide)
- `SECURITY.md` (security policy and private vulnerability reporting)
- `CHANGELOG.md` (changelog scaffold)

No code changes. Security contact is michael.chirillo@uri.edu.

Reviewer: Michael

Closes #76