### PR TITLE
chore: update maintainer email in developers.py

### DIFF
--- a/PyReconstruct/modules/constants/developers.py
+++ b/PyReconstruct/modules/constants/developers.py
@@ -1,6 +1,6 @@
 developers_data = [
     {"name": "Julian Falco", "email": "julian.falco@utexas.edu"},
-    {"name": "Michael Chirillo", "email": "m.chirillo@utexas.edu"}
+    {"name": "Michael Chirillo", "email": "michael.chirillo@uri.edu"}
 ]
 
 developers_names = [person["name"] for person in developers_data]


### PR DESCRIPTION
Updates Michael Chirillo's contact email in `PyReconstruct/modules/constants/developers.py` from the stale `m.chirillo@utexas.edu` to `michael.chirillo@uri.edu`. One-line change, no behavior change.

Closes #80