### PR TITLE
fix(gui): reword the skipped-traces dialog (traces, not "malformed contours")

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,11 @@
+---
+name: Chore or Task
+about: Create a chore or tasks (usually used only internally for development)
+title: ''
+labels: chore
+assignees: ''
+
+---
+
+[A concise description of the chore to be completed.]
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vijay"]
-	path = src/modules/backend/autoseg/vijay
-	url = https://github.com/yajivunev/autoseg

--- a/PyReconstruct/modules/constants/developers.py
+++ b/PyReconstruct/modules/constants/developers.py
@@ -1,6 +1,6 @@
 developers_data = [
     {"name": "Julian Falco", "email": "julian.falco@utexas.edu"},
-    {"name": "Michael Chirillo", "email": "m.chirillo@utexas.edu"}
+    {"name": "Michael Chirillo", "email": "michael.chirillo@uri.edu"}
 ]
 
 developers_names = [person["name"] for person in developers_data]

--- a/PyReconstruct/modules/gui/dialog/malformed_contours.py
+++ b/PyReconstruct/modules/gui/dialog/malformed_contours.py
@@ -57,7 +57,7 @@ class MalformedContoursDialog(QDialog):
         self.navigate = navigate
         self.delete = delete
 
-        self.setWindowTitle("Malformed contours skipped while smoothing")
+        self.setWindowTitle("Traces skipped during smoothing")
         self.resize(660, 420)
 
         self.heading = QLabel(self._headingText(), self)
@@ -76,23 +76,23 @@ class MalformedContoursDialog(QDialog):
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.table.cellDoubleClicked.connect(self._onDoubleClick)
 
-        self.goto_button = QPushButton("Go to contour", self)
+        self.goto_button = QPushButton("Go to trace", self)
         self.goto_button.setToolTip(
-            "Focus the field on the selected contour"
+            "Focus the field on the selected trace"
         )
         self.goto_button.setEnabled(False)
         self.goto_button.clicked.connect(self.goToSelectedContour)
 
         copy_button = QPushButton("Copy table list", self)
         copy_button.setToolTip(
-            "Copy the table of malformed contours above to the clipboard "
+            "Copy the table of skipped traces above to the clipboard "
             "(tab-separated, including the column headers)"
         )
         copy_button.clicked.connect(self.copyToClipboard)
 
         save_button = QPushButton("Save table as CSV…", self)
         save_button.setToolTip(
-            "Save the table of malformed contours above to a CSV file"
+            "Save the table of skipped traces above to a CSV file"
         )
         save_button.clicked.connect(self.saveCSV)
 
@@ -102,7 +102,7 @@ class MalformedContoursDialog(QDialog):
         if self.delete:
             self.delete_selected_button = QPushButton("Delete selected", self)
             self.delete_selected_button.setToolTip(
-                "Delete the selected contour(s) from the series (can be undone)"
+                "Delete the selected trace(s) from the series (can be undone)"
             )
             self.delete_selected_button.setEnabled(False)
             self.delete_selected_button.clicked.connect(
@@ -111,7 +111,7 @@ class MalformedContoursDialog(QDialog):
 
             self.delete_all_button = QPushButton("Delete all", self)
             self.delete_all_button.setToolTip(
-                "Delete every contour listed above from the series "
+                "Delete every trace listed above from the series "
                 "(can be undone)"
             )
             self.delete_all_button.setEnabled(bool(self.records))
@@ -144,7 +144,7 @@ class MalformedContoursDialog(QDialog):
         num_traces = len(self.records)
         if not num_traces:
             return (
-                "All listed malformed contours have been deleted.\n\n"
+                "All listed traces have been deleted.\n\n"
                 "You can close this window."
             )
 
@@ -154,17 +154,17 @@ class MalformedContoursDialog(QDialog):
         was_were = "was" if num_traces == 1 else "were"
 
         action = (
-            "Select one or more rows, then use “Go to contour” to focus the "
+            "Select one or more rows, then use “Go to trace” to focus the "
             "field, or “Delete selected” / “Delete all” to remove them."
             if self.delete
-            else "Select a row and click “Go to contour” to focus the field "
+            else "Select a row and click “Go to trace” to focus the field "
             "on that trace."
         )
 
         return (
-            f"{num_traces} contour {trace_word} across {num_objs} {obj_word} "
-            f"{was_were} skipped while smoothing.\n\n"
-            "A trace is malformed when it cannot be smoothed — usually "
+            f"{num_traces} {trace_word} across {num_objs} {obj_word} "
+            f"{was_were} skipped during smoothing.\n\n"
+            "A trace is skipped when it cannot be smoothed — usually "
             "because it has too few points to interpolate a curve (fewer "
             "than 3). These traces were left unchanged; the Reason column "
             "explains why each one was skipped.\n\n"
@@ -269,9 +269,9 @@ class MalformedContoursDialog(QDialog):
         if not self.delete or not records:
             return
         count = len(records)
-        noun = "contour" if count == 1 else "contours"
+        noun = "trace" if count == 1 else "traces"
         if not notifyConfirm(
-            f"Delete {count} malformed {noun} from the series?\n\n"
+            f"Delete {count} {noun} from the series?\n\n"
             "This can be undone (Ctrl+Z).",
             yn=True,
         ):
@@ -325,8 +325,8 @@ class MalformedContoursDialog(QDialog):
         """Save the report to a CSV file the user chooses."""
         fp, _ = QFileDialog.getSaveFileName(
             self,
-            "Save malformed contours",
-            "malformed_contours.csv",
+            "Save skipped traces",
+            "skipped_traces.csv",
             "CSV files (*.csv);;All files (*)",
         )
         if not fp:

--- a/PyReconstruct/modules/gui/dialog/malformed_contours.py
+++ b/PyReconstruct/modules/gui/dialog/malformed_contours.py
@@ -20,13 +20,13 @@ from PyReconstruct.modules.gui.utils import notifyConfirm
 
 
 class MalformedContoursDialog(QDialog):
-    """Report contours skipped during object smoothing for being malformed.
+    """Report traces skipped during object smoothing.
 
     Each row is one trace that could not be smoothed (typically too few
     points to interpolate a curve). The dialog shows enough context to track
     each one down: the object, the section, how many points the trace had,
     where it sits, and why it was skipped. Selecting a row and clicking
-    "Go to contour" (or double-clicking the row) focuses the field on it, and
+    "Go to trace" (or double-clicking the row) focuses the field on it, and
     the list can be copied or exported for triage.
     """
 
@@ -34,7 +34,7 @@ class MalformedContoursDialog(QDialog):
 
     def __init__(self, mainwindow: QWidget, records: list, navigate=None,
                  delete=None):
-        """Create the malformed-contours dialog.
+        """Create the skipped-traces dialog.
 
             Params:
                 mainwindow (QWidget): the parent window
@@ -229,7 +229,7 @@ class MalformedContoursDialog(QDialog):
         return self._records_by_key.get(item.data(Qt.UserRole))
 
     def _navigateToRow(self, row):
-        """Focus the field on the contour in the given table row."""
+        """Focus the field on the trace in the given table row."""
         if not self.navigate:
             return
         record = self._recordAtRow(row)
@@ -238,13 +238,13 @@ class MalformedContoursDialog(QDialog):
         self.navigate(record["section"], record["name"])
 
     def goToSelectedContour(self):
-        """Focus the field on the currently selected contour."""
+        """Focus the field on the currently selected trace."""
         rows = self.table.selectionModel().selectedRows()
         if rows:
             self._navigateToRow(rows[0].row())
 
     def _onDoubleClick(self, row, _col):
-        """Focus the field on the double-clicked contour."""
+        """Focus the field on the double-clicked trace."""
         self._navigateToRow(row)
 
     def _selectedRecords(self):
@@ -257,11 +257,11 @@ class MalformedContoursDialog(QDialog):
         return records
 
     def deleteSelectedContours(self):
-        """Delete the contours for the currently selected rows."""
+        """Delete the traces for the currently selected rows."""
         self._deleteRecords(self._selectedRecords())
 
     def deleteAllContours(self):
-        """Delete every contour listed in the dialog."""
+        """Delete every trace listed in the dialog."""
         self._deleteRecords(list(self.records))
 
     def _deleteRecords(self, records):


### PR DESCRIPTION
Closes #74

Wording change to the dialog shown after smoothing objects. Renames its title to "Traces skipped during smoothing" and refers to the listed items as skipped traces rather than "malformed contours."

Why: "malformed" implied an inherent fault, but the actual per-row reason is already shown in the Reason column (user feedback from Lyndsey). And each row is a single trace instance, not a contour, since a contour is all traces of an object on a section (terminology note from Michael).

No behavior change. Only user-facing strings (window title, heading, button and tooltip labels, confirm text, save-dialog title and filename) plus the matching docstrings. Code identifiers are unchanged.