### PR TITLE
fix(gui): match Trace List zoom when jumping to a skipped trace

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,11 @@
+---
+name: Chore or Task
+about: Create a chore or tasks (usually used only internally for development)
+title: ''
+labels: chore
+assignees: ''
+
+---
+
+[A concise description of the chore to be completed.]
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vijay"]
-	path = src/modules/backend/autoseg/vijay
-	url = https://github.com/yajivunev/autoseg

--- a/PyReconstruct/modules/constants/developers.py
+++ b/PyReconstruct/modules/constants/developers.py
@@ -1,6 +1,6 @@
 developers_data = [
     {"name": "Julian Falco", "email": "julian.falco@utexas.edu"},
-    {"name": "Michael Chirillo", "email": "m.chirillo@utexas.edu"}
+    {"name": "Michael Chirillo", "email": "michael.chirillo@uri.edu"}
 ]
 
 developers_names = [person["name"] for person in developers_data]

--- a/PyReconstruct/modules/datatypes/series.py
+++ b/PyReconstruct/modules/datatypes/series.py
@@ -1293,11 +1293,13 @@ class Series():
             Returns:
                 (list): one record per skipped trace, each a dict with keys
                     "name" (object name), "section" (section number),
-                    "points" (point count), "location" ((x, y) of the first
-                    point, or None when the trace has no points), "reason"
-                    (why it was skipped) and "match" (a {"color", "points"}
-                    signature used to re-find and delete the trace later).
-                    Empty when nothing was skipped.
+                    "points" (point count), "index" (the trace's position
+                    within the contour on that section, used to focus the
+                    field on that exact trace), "location" ((x, y) of the
+                    first point, or None when the trace has no points),
+                    "reason" (why it was skipped) and "match" (a
+                    {"color", "points"} signature used to re-find and delete
+                    the trace later). Empty when nothing was skipped.
         """
 
         window = self.getOption("roll_window")
@@ -1323,7 +1325,7 @@ class Series():
 
                     smoothed_any = False
 
-                    for trace in obj.traces:
+                    for index, trace in enumerate(obj.traces):
 
                         if trace.smooth(window=window, spacing=0.004):
 
@@ -1336,6 +1338,9 @@ class Series():
                             malformed.append({
                                 "name": obj_name,
                                 "section": snum,
+                                # position within the contour, so the dialog can
+                                # frame this exact trace (findTrace) on go-to
+                                "index": index,
                                 "points": num_points,
                                 "location": (
                                     tuple(round(c, 4) for c in trace.points[0])

--- a/PyReconstruct/modules/gui/dialog/malformed_contours.py
+++ b/PyReconstruct/modules/gui/dialog/malformed_contours.py
@@ -41,8 +41,9 @@ class MalformedContoursDialog(QDialog):
                 records (list): list of dicts, each with keys "name",
                     "section", "points", "location" ((x, y) or None), "reason"
                     and "trace" (the Trace object, used for deletion)
-                navigate (callable): optional navigate(section_num, obj_name)
-                    callback used to focus the field on a double-clicked row
+                navigate (callable): optional navigate(section_num, obj_name,
+                    index) callback used to focus the field on a
+                    double-clicked row
                 delete (callable): optional delete(records) callback that
                     removes the given records from the series and returns the
                     records actually deleted; the Delete buttons are only shown
@@ -235,7 +236,7 @@ class MalformedContoursDialog(QDialog):
         record = self._recordAtRow(row)
         if record is None:
             return
-        self.navigate(record["section"], record["name"])
+        self.navigate(record["section"], record["name"], record["index"])
 
     def goToSelectedContour(self):
         """Focus the field on the currently selected contour."""

--- a/PyReconstruct/modules/gui/main/field_widget_3_object.py
+++ b/PyReconstruct/modules/gui/main/field_widget_3_object.py
@@ -192,12 +192,16 @@ class FieldWidgetObject(FieldWidgetTrace):
 
         return True
 
-    def focusMalformedContour(self, section_num: int, obj_name: str):
-        """Focus the field on a contour reported in the malformed dialog."""
+    def focusMalformedContour(self, section_num: int, obj_name: str, index: int = 0):
+        """Focus the field on a trace reported in the malformed dialog."""
 
-        # route through the canonical navigation path so an in-progress trace
-        # is finalized and field data is saved before the section switch
-        self.mainwindow.setToObject(obj_name, section_num)
+        # switch to the trace's section first (changeSection finalizes any
+        # in-progress trace and saves field data before the switch), then frame
+        # the individual trace the way the Trace List does, rather than the
+        # whole object
+        self.mainwindow.changeSection(section_num)
+        self.mainwindow.field.findTrace(obj_name, index)
+        self.mainwindow.field.setFocus()
 
     def deleteMalformedContours(self, records: list) -> list:
         """Delete malformed contours chosen in the dialog.


### PR DESCRIPTION
Closes #84

The skipped-traces dialog's "Go to trace" action routed through `setToObject`, which frames the whole object and leaves the view zoomed out. It now uses the same mechanism the Trace List uses, `field.findTrace(name, index)`, so the view centers and zooms on the individual trace.

To frame the exact trace (an object can have several skipped traces on one section, e.g. pixel dust), `smoothObject` now records each skipped trace's index within its contour, and the dialog passes it through its `navigate` callback. The handler changes to the trace's section first, finalizing any in-progress trace and saving field data before the switch.

Reuses existing core methods (`changeSection`, `field.findTrace`); no new navigation or zoom logic added.