### PR TITLE
feat(table): show a progress bar when locking/unlocking multiple sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,11 @@
+---
+name: Chore or Task
+about: Create a chore or tasks (usually used only internally for development)
+title: ''
+labels: chore
+assignees: ''
+
+---
+
+[A concise description of the chore to be completed.]
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vijay"]
-	path = src/modules/backend/autoseg/vijay
-	url = https://github.com/yajivunev/autoseg

--- a/PyReconstruct/modules/constants/developers.py
+++ b/PyReconstruct/modules/constants/developers.py
@@ -1,6 +1,6 @@
 developers_data = [
     {"name": "Julian Falco", "email": "julian.falco@utexas.edu"},
-    {"name": "Michael Chirillo", "email": "m.chirillo@utexas.edu"}
+    {"name": "Michael Chirillo", "email": "michael.chirillo@uri.edu"}
 ]
 
 developers_names = [person["name"] for person in developers_data]

--- a/PyReconstruct/modules/gui/table/section.py
+++ b/PyReconstruct/modules/gui/table/section.py
@@ -210,22 +210,31 @@ class SectionTableWidget(DataTable):
         
         self.mainwindow.saveAllData()
 
-        # set up progress
-        progbar = getProgbar(
-            text=f"{'Locking' if lock else 'Unlocking'} sections...",
-            cancel=False
-        )
+        # set up progress (skip for single sections, e.g. a lock checkbox toggle)
         progress = 0
         final_value = len(section_numbers)
+        if final_value > 1:
+            progbar = getProgbar(
+                text=f"{'Locking' if lock else 'Unlocking'} sections...",
+                cancel=False
+            )
+        else:
+            progbar = None
 
-        for snum in section_numbers:
-            section = self.series.loadSection(snum)
-            section.align_locked = lock
-            section.save()
-            if log_event:
-                self.series.addLog(None, snum, f"{'Lock' if lock else 'Unlock'} section")
-            progress += 1
-            progbar.setValue(progress/final_value * 100)
+        try:
+            for snum in section_numbers:
+                section = self.series.loadSection(snum)
+                section.align_locked = lock
+                section.save()
+                if log_event:
+                    self.series.addLog(None, snum, f"{'Lock' if lock else 'Unlock'} section")
+                progress += 1
+                if progbar is not None:
+                    progbar.setValue(progress/final_value * 100)
+        finally:
+            # make sure the dialog is closed if the loop exits early
+            if progbar is not None and progress < final_value:
+                progbar.close()
 
         self.manager.updateSections(section_numbers)
         

--- a/PyReconstruct/modules/gui/table/section.py
+++ b/PyReconstruct/modules/gui/table/section.py
@@ -14,7 +14,8 @@ from PyReconstruct.modules.gui.utils import (
     populateMenuBar,
     populateMenu,
     noUndoWarning,
-    notify
+    notify,
+    getProgbar
 )
 from PyReconstruct.modules.gui.dialog import QuickDialog, FileDialog
 from PyReconstruct.modules.datatypes import Series
@@ -209,13 +210,23 @@ class SectionTableWidget(DataTable):
         
         self.mainwindow.saveAllData()
 
+        # set up progress
+        progbar = getProgbar(
+            text=f"{'Locking' if lock else 'Unlocking'} sections...",
+            cancel=False
+        )
+        progress = 0
+        final_value = len(section_numbers)
+
         for snum in section_numbers:
             section = self.series.loadSection(snum)
             section.align_locked = lock
             section.save()
             if log_event:
                 self.series.addLog(None, snum, f"{'Lock' if lock else 'Unlock'} section")
-        
+            progress += 1
+            progbar.setValue(progress/final_value * 100)
+
         self.manager.updateSections(section_numbers)
         
         # update the field


### PR DESCRIPTION
Bulk lock/unlock from the section list (the right-click menu actions and the lock checkbox column) loads and saves every selected section with no feedback, which reads as a hang on large selections. This drives a progress dialog over that loop so the user can see the operation advancing.

## What changed

- `SectionTableWidget.lockSections()` in `PyReconstruct/modules/gui/table/section.py` now creates a non-cancelable progress dialog via the existing `getProgbar` helper and updates it once per section saved, scaled from 0 to 100.
- The dialog is only created when more than one section is selected, so the common single-checkbox toggle path stays exactly as cheap as before and never allocates a dialog.
- The loop is wrapped in `try/finally` so the dialog is force-closed if a section load/save raises mid-run; on normal completion, `setValue(100)` auto-resets it as usual.

## Notes

- This mirrors the approach of #62 (progress bar for the Zarr conversion) and the established `getProgbar` idiom already used by `Series.enumerateSections` and the series open path; no new progress mechanism is introduced.
- The dialog's 1.5 s minimum duration means quick operations never flash a dialog; empty selections still return early before any progress setup.
- All lock/unlock behavior (section data, log events, table/field refresh) is unchanged.

Closes #88