### PR TITLE
feat(align): propagate align-by-correlation across a range of sections

### DIFF
--- a/PyReconstruct/modules/gui/main/field_widget_4_data.py
+++ b/PyReconstruct/modules/gui/main/field_widget_4_data.py
@@ -411,10 +411,14 @@ class FieldWidgetData(FieldWidgetObject):
         shift_tform = Transform([1, 0, shift_x, 0, 1, shift_y])
 
         tform = self.section.tform
-        self.section.tform = shift_tform * tform
-
-        self.generateView()
-        self.saveState()
+        # the shift is measured in field space, so it must be applied after the
+        # section's own transform (tform * shift_tform); composing it before
+        # gives the wrong result whenever the tform has rotation or scale.
+        # route through changeTform so that, when propagation mode is active,
+        # the shift is recorded in stored_tform and can be propagated across a
+        # range of sections like a manual transform. changeTform also handles
+        # generateView and saveState.
+        self.changeTform(tform * shift_tform)
 
     def calibrateMag(self, trace_lengths : dict, log_event=True):
         """Calibrate the pixel mag based on the lengths of given traces.

--- a/PyReconstruct/modules/gui/main/field_widget_4_data.py
+++ b/PyReconstruct/modules/gui/main/field_widget_4_data.py
@@ -215,13 +215,20 @@ class FieldWidgetData(FieldWidgetObject):
                 )
                 if modify_section: included_sections.append(snum)
         
+        # locked sections are left untouched: warn the user, then exclude them
+        locked_sections = set()
         for snum in included_sections:
             section = self.series.loadSection(snum)
             if section.align_locked:
-                if not notifyConfirm("Locked sections will not be modified.\nWould you still like to propagate the transform?"):
-                    return
-                break
-        
+                locked_sections.add(snum)
+        if locked_sections:
+            if not notifyConfirm("Locked sections will not be modified.\nWould you still like to propagate the transform?"):
+                return
+            included_sections = [
+                snum for snum in included_sections
+                if snum not in locked_sections
+            ]
+
         # create the progress bar
         if included_sections:
             progbar = getProgbar(
@@ -232,12 +239,20 @@ class FieldWidgetData(FieldWidgetObject):
             final_value = len(included_sections)
             progbar.setValue(0)
 
+            # record a series-wide undo state for the propagation
+            self.series_states.addState()
+
             try:
                 for snum in included_sections:
                     section = self.series.loadSection(snum)
+                    # capture the section's pre-modification state
+                    self.series_states[section]
                     new_tform = self.stored_tform * section.tform
                     section.tform = new_tform
                     section.save()
+                    # record the undo state so the propagation is undoable
+                    self.series_states[snum].addState(section, self.series)
+                    self.series_states.addSectionUndo(snum)
                     self.propagated_sections.add(snum)
                     if log_event:
                         self.series.addLog(None, snum, "Modify transform")


### PR DESCRIPTION
Lets an Align by correlation (Ctrl+\) result propagate across a range of sections, the same way a manual transform already can, by routing corrAlign through changeTform. Also corrects the shift composition order for rotated or scaled sections, and fixes propagateTo to actually skip locked sections and record undo state.

Closes #95.