### PR TITLE
fix(gui): stop affineAlign when fewer than three traces selected

### DIFF
--- a/PyReconstruct/modules/gui/main/field_widget_4_data.py
+++ b/PyReconstruct/modules/gui/main/field_widget_4_data.py
@@ -356,6 +356,7 @@ class FieldWidgetData(FieldWidgetObject):
         blen = len(b_traces)
         if alen < 3:
             notify("Please select 3 or more traces for aligning.")
+            return
         if alen != blen:
             notify("Please select the same number of traces on each section.")
             return


### PR DESCRIPTION
`affineAlign` showed the "select 3 or more traces" notification but did not return, so it fell through into the alignment code with an invalid selection. With equal counts under three this silently applied a bogus or NaN transform to the section and saved it, and with nothing selected it raised an unhandled `IndexError`. This adds the missing `return` after the notification so the guard stops execution.

Closes #106.