### PR TITLE
fix: pass converter commands as argv lists instead of via a shell

### DIFF
--- a/PyReconstruct/modules/gui/main/main_window.py
+++ b/PyReconstruct/modules/gui/main/main_window.py
@@ -411,7 +411,7 @@ class MainWindow(QMainWindow):
                 str(zarr_converter.absolute()),
                 "convert_zarr",
                 str(cores),
-                f"\"{self.series.src_dir}\"",
+                self.series.src_dir,
                 zarr_fp
             ]
 
@@ -421,19 +421,20 @@ class MainWindow(QMainWindow):
                 str(zarr_converter.absolute()),
                 "convert_zarr",
                 str(cores),
-                f"\"{self.series.src_dir}\""
+                self.series.src_dir
             ]
 
+        # Pass argv as a list on every platform, never through a shell, so paths
+        # read from the series file stay single literal arguments.
         if os.name == 'nt':
 
             subprocess.Popen(
                 convert_cmd, creationflags=subprocess.CREATE_NO_WINDOW
             )
-            
+
         else:
 
-            convert_cmd = " ".join(convert_cmd)
-            subprocess.Popen(convert_cmd, shell=True, stdout=None, stderr=None)
+            subprocess.Popen(convert_cmd, stdout=None, stderr=None)
 
     def changeUsername(self, new_name : str = None):
         """Edit the login name used to track history.
@@ -1997,7 +1998,7 @@ class MainWindow(QMainWindow):
         convert_cmd = launch_prefix + [
             str(zarr_converter.absolute()),
             "create_ng_zarr",
-            f"\"{self.series.jser_fp}\""
+            self.series.jser_fp
         ]
 
         for argname, arg in args.items():
@@ -2010,24 +2011,25 @@ class MainWindow(QMainWindow):
 
                         convert_cmd += [
                             "--output",
-                            f"\"{arg}\""
+                            str(arg)
                         ]
-                        
+
                     else:
 
                         convert_cmd += [argname] + str(arg).split()
 
+        # Pass argv as a list on every platform, never through a shell, so paths
+        # read from the series file stay single literal arguments.
         if os.name == 'nt':
 
             subprocess.Popen(
                 convert_cmd,
                 creationflags=subprocess.CREATE_NO_WINDOW
             )
-            
+
         else:
 
-            convert_cmd = " ".join(convert_cmd)
-            subprocess.Popen(convert_cmd, shell=True, stdout=None, stderr=None)
+            subprocess.Popen(convert_cmd, stdout=None, stderr=None)
     
     # AUTOSEG FUNCTIONS TEMPORARILY REMOVED
 


### PR DESCRIPTION
Passes the two converter commands as argv lists instead of joining them into a string and running them through a shell, which closes an arbitrary-command-execution path from a shared series file.

## Root cause

The scaled-zarr converter and the neuroglancer export built their commands by f-string-quoting fields taken from the series (`series.src_dir`, `series.jser_fp`, and the `--output` argument) and ran them with `subprocess.Popen(..., shell=True)` on non-Windows platforms:

```python
f"\"{self.series.src_dir}\"",
...
convert_cmd = " ".join(convert_cmd)
subprocess.Popen(convert_cmd, shell=True, stdout=None, stderr=None)
```

`src_dir` is read verbatim from `series_data["src_dir"]` in the `.jser`. Double quotes do not neutralize a shell: `$(...)`, backticks, and a closing quote followed by `;` or `&&` all execute. Opening a series prepared by someone else and then running a conversion, the ordinary next step, runs whatever the field contains, with the user's privileges and no visible sign.

## Change

Pass `convert_cmd` as a list to `subprocess.Popen` on every platform, with each path a single literal element, and drop `shell=True` and the manual quoting. The Windows branch already passed a list, so both platforms now share the same argv. Legitimate paths, including paths with spaces, are handled correctly by construction, which is what the quoting was reaching for.

Covers both launch sites: `convert_zarr` and `create_ng_zarr`.

## Notes

Detail and a reproduction are in the linked issue.

Closes #113
