### PR TITLE
feat(autoseg): readable, colorblind-safe colors for autoseg import

### DIFF
--- a/PyReconstruct/modules/backend/autoseg/conversions.py
+++ b/PyReconstruct/modules/backend/autoseg/conversions.py
@@ -11,7 +11,9 @@ import zarr
 from PyReconstruct.modules.datatypes import Series, Transform, Trace
 from PyReconstruct.modules.backend.view import SectionLayer
 from PyReconstruct.modules.backend.threading import ThreadPoolProgBar
-from PyReconstruct.modules.calc import colorize, reducePoints
+from PyReconstruct.modules.calc import reducePoints
+
+from .palette import DEFAULT_AUTOSEG_PALETTE, palette_color
 
 
 dt = None
@@ -546,12 +548,6 @@ def exterior_to_points(ext: list[np.ndarray], offset, resolution, raw, window, t
     return trace_points
 
 
-def colorize_id(id):
-    """Return color for ID."""
-
-    return tuple(map(int, colorize(id)))
-
-
 def exportSection(data_zg,
                   snum : int,
                   series : Series,
@@ -742,7 +738,12 @@ def importSection(data_zg, group, snum, series, ids=None):
     ## Iterate through label ids
     if ids is None:
         ids = np.unique(arr)
-        
+
+    ## Resolve the trace-color palette + seed once for this section.
+    ## An empty/unset override falls back to the shipped curated default.
+    palette = series.getOption("autoseg_color_palette") or DEFAULT_AUTOSEG_PALETTE
+    color_seed = series.getOption("autoseg_color_seed") or 0
+
     for id in ids:
         
         if id == 0:
@@ -755,7 +756,7 @@ def importSection(data_zg, group, snum, series, ids=None):
         for ext in exteriors:
 
             trace_name = f"autoseg_{id}"
-            trace_color = colorize_id(id)
+            trace_color = palette_color(id, palette, color_seed)
 
             trace = Trace(name=trace_name, color=trace_color)
             trace.points = exterior_to_points(ext, offset, resolution, raw, window, tform, mag)

--- a/PyReconstruct/modules/backend/autoseg/palette.py
+++ b/PyReconstruct/modules/backend/autoseg/palette.py
@@ -1,0 +1,203 @@
+"""Curated color palette for autoseg-imported traces.
+
+Autoseg import turns each segmentation label id into a trace/object. The color
+those traces get needs to stand out against a grayscale EM image, and it needs
+to be *stable*: the same label id spans many sections, so every section must
+paint it the same color or a single object ends up multicolored.
+
+Design (mirrors how neuroglancer keeps segment colors readable on gray):
+
+* Colors are drawn from a small curated whitelist rather than an arbitrary RGB
+  cube. Every entry is high-value and clearly chromatic, so it sits well off the
+  achromatic ("gray") axis and away from near-black tones. That is exactly the
+  region of color space a grayscale background cannot camouflage.
+
+* The whitelist is also color-vision-deficiency (CVD) safe: the 12 colors stay
+  mutually distinguishable under deuteranopia, protanopia, and tritanopia. See
+  the palette comment below for the analysis; the tests assert a minimum
+  perceptual separation (CIEDE2000) under each simulated deficiency.
+
+* The label id is mapped to a palette entry *deterministically* by hashing the
+  id (with an adjustable seed) and indexing into the palette. Determinism is not
+  just nice-to-have here: import runs per-section, so a random pick would give
+  the same label a different color on each section. Hashing guarantees one label
+  id -> one color everywhere, reproducibly across sessions.
+
+* The seed is a global "re-roll" knob (neuroglancer's color-seed idea): bump it
+  and the whole id->color assignment shifts, which lets a user break up an
+  unlucky case where two touching labels landed on similar colors.
+
+The palette below is the shipped default and is meant to be easy to edit in one
+place. It can also be overridden per computer/series via the
+``autoseg_color_palette`` and ``autoseg_color_seed`` options (see
+``modules/datatypes/default_settings.py``); an empty override falls back to this
+default.
+"""
+
+# 12 CVD-safe, grayscale-visible colors. Each is high-value and clearly
+# chromatic (never a shade of gray, never near-black), and the set stays
+# mutually distinguishable under all three main color-vision deficiencies.
+# Values are (R, G, B) integers in 0-255 -- the format Trace expects.
+#
+# Derivation: seeded with the seven non-black colors of the Okabe-Ito CVD-safe
+# palette (Okabe & Ito 2008 -- the accessibility standard), then extended to 12
+# by farthest-point selection under the worst case across normal vision plus
+# simulated deuteranopia/protanopia/tritanopia (Machado et al. 2009 matrices),
+# using CIEDE2000 as the perceptual distance. Ordered most-distinct-first so a
+# future sequential-assignment mode would use the best-separated colors first
+# (the current hash-based assignment draws from all 12, so order is cosmetic).
+#
+# Measured worst-case minimum pairwise CIEDE2000 separation:
+#   normal 15.2, protanopia 12.3, deuteranopia 11.6, tritanopia 10.9
+# CVD-safety forces the set toward the blue-yellow and lightness axes (the
+# red-green axis collapses under deuteranopia/protanopia), which is why several
+# blues appear -- this is the same reason the Okabe-Ito standard looks as it
+# does. A wider spread of hues is not achievable without colors that merge
+# under red-green deficiency.
+DEFAULT_AUTOSEG_PALETTE = [
+    (240, 228,  66),   # yellow
+    (  0,   0, 178),   # blue
+    (178,   0,   0),   # red
+    ( 86, 180, 233),   # sky blue
+    (  0, 114, 178),   # azure
+    (213,  94,   0),   # vermillion
+    ( 51, 255, 187),   # aqua
+    (178,  36, 112),   # magenta
+    (204, 121, 167),   # pink
+    (  0, 158, 115),   # green
+    ( 89, 133, 255),   # cornflower
+    (230, 159,   0),   # orange
+]
+
+
+def _mix(value: int, seed: int) -> int:
+    """Deterministically scramble an integer (splitmix64/Murmur3 finalizer).
+
+    Good avalanche so consecutive label ids (1, 2, 3, ...) land on different
+    palette entries. Uses only integer arithmetic, so it is independent of
+    PYTHONHASHSEED and identical across processes and sessions.
+    """
+    mask = 0xFFFFFFFFFFFFFFFF
+    h = (int(value) ^ int(seed)) & mask
+    h = ((h ^ (h >> 33)) * 0xFF51AFD7ED558CCD) & mask
+    h = ((h ^ (h >> 33)) * 0xC4CEB9FE1A85EC53) & mask
+    h = h ^ (h >> 33)
+    return h
+
+
+def palette_color(label_id, palette=None, seed: int = 0) -> tuple:
+    """Return a stable (R, G, B) color for a segmentation label id.
+
+        Params:
+            label_id: the segmentation label id (int-like)
+            palette: list of (R, G, B) entries; falls back to the shipped
+                default when None or empty
+            seed (int): re-roll seed; the same id + seed always yields the same
+                color, and changing the seed reshuffles the whole assignment
+        Returns:
+            (tuple): an (R, G, B) integer triple, 0-255, taken from the palette
+    """
+    if not palette:
+        palette = DEFAULT_AUTOSEG_PALETTE
+    index = _mix(int(label_id), seed) % len(palette)
+    return tuple(int(c) for c in palette[index])
+
+
+def next_shuffle_seed(current_seed: int, palette=None, ids=None, rng=None) -> int:
+    """Pick a new seed whose color arrangement differs from the current one.
+
+    This backs the "Shuffle colors" button: each click must visibly change the
+    id -> color assignment. A fresh random seed almost always does, but two
+    seeds *can* land on the same arrangement, so we draw candidates until one
+    actually differs -- that makes "a click always reshuffles" a guarantee, not
+    a near-certainty. The result is a concrete integer stored in the series
+    option, so determinism and preview==import are preserved exactly as with a
+    hand-entered seed.
+
+    The guarantee is enforced over ``ids``: the label ids the caller can
+    actually see. With only a few labels on screen, a generic 1..63 fingerprint
+    can "change" while none of the *visible* labels move color -- a no-op click
+    for the user. Passing the overlay's present ids ties the guarantee to what
+    is on screen. When ``ids`` is None (or has no usable entries) it falls back
+    to the 1..63 range, which reaches every palette entry.
+
+        Params:
+            current_seed (int): the seed currently in effect
+            palette: list of (R, G, B) entries; falls back to the shipped
+                default when None or empty
+            ids: optional iterable of label ids to fingerprint the arrangement
+                over (the visible/present ids); None uses the default 1..63
+                range
+            rng: an optional random.Random (injectable for deterministic tests);
+                a fresh default source is used when None
+        Returns:
+            (int): a new non-negative seed that produces a different arrangement,
+                or ``current_seed`` unchanged if the palette has fewer than two
+                colors (no reshuffle is possible)
+    """
+    import random
+
+    if rng is None:
+        rng = random.Random()
+    if not palette:
+        palette = DEFAULT_AUTOSEG_PALETTE
+
+    # With <2 colors every id maps to the same entry: no reshuffle exists.
+    if len(palette) < 2:
+        return int(current_seed)
+
+    # Fingerprint the arrangement over the visible ids when supplied (id 0 is
+    # background, not a segment, so it is dropped); otherwise a 1..63 sample,
+    # which reaches every entry so two seeds agreeing across all of them means
+    # the mapping is identical.
+    if ids is None:
+        sample = range(1, 64)
+    else:
+        sample = [int(i) for i in ids if i]
+        if not sample:
+            sample = range(1, 64)
+
+    def arrangement(seed):
+        return tuple(palette_color(i, palette, seed) for i in sample)
+
+    current = arrangement(int(current_seed))
+    for _ in range(1000):
+        candidate = rng.randrange(1, 2 ** 31)
+        if candidate == int(current_seed):
+            continue
+        if arrangement(candidate) != current:
+            return candidate
+    return int(current_seed)
+
+
+def palette_color_array(label_array, palette=None, seed: int = 0,
+                        background=(0, 0, 0)):
+    """Vectorized palette_color for a 2-D array of label ids.
+
+    Used to render the live label overlay in the exact same colors the import
+    would assign, so the preview matches the resulting traces. Returns an
+    (H, W, 3) uint8 array.
+
+        Params:
+            label_array: 2-D array of integer label ids
+            palette: see palette_color
+            seed (int): see palette_color
+            background: (R, G, B) for label id 0 (not a segment)
+        Returns:
+            an (H, W, 3) uint8 numpy array
+
+    Colors are resolved once per *unique* id (few) via palette_color, then
+    scattered back to every pixel. Doing it per-unique-id both reuses the exact
+    scalar mapping and sidesteps 64-bit overflow that a fully vectorized hash
+    would hit in numpy integer types.
+    """
+    import numpy as np
+
+    arr = np.asarray(label_array)
+    unique, inverse = np.unique(arr, return_inverse=True)
+    lut = np.array(
+        [background if int(u) == 0 else palette_color(u, palette, seed)
+         for u in unique.tolist()],
+        dtype=np.uint8,
+    )
+    return lut[inverse].reshape(arr.shape + (3,))

--- a/PyReconstruct/modules/backend/view/zarr_layer.py
+++ b/PyReconstruct/modules/backend/view/zarr_layer.py
@@ -17,7 +17,7 @@ from PyReconstruct.modules.datatypes import (
     Section
 )
 
-from PyReconstruct.modules.calc import colorize, pixmapPointToField
+from PyReconstruct.modules.calc import pixmapPointToField
 
 class ZarrLayer():
 
@@ -117,6 +117,25 @@ class ZarrLayer():
                 self.selected_ids.append(label_id)
             return True
         return False
+
+    def getPresentIds(self):
+        """Return the label ids visible on the current section.
+
+        These are the unique non-zero ids in the current section's slice of the
+        label overlay -- i.e. the labels the user actually sees colored (the
+        whole crop is colored, not just ``selected_ids``). Used to tie the
+        shuffle-colors guarantee to what is on screen. Returns an empty list
+        when this is not a label overlay or the current section falls outside
+        the overlay's z-range.
+        """
+        if not self.is_labels:
+            return []
+        bz = self.zarr.shape[0]
+        z = round(self.section.n - self.zarr_s)
+        if not 0 <= z < bz:
+            return []
+        present = np.unique(self.zarr[z])
+        return [int(v) for v in present.tolist() if v != 0]
 
     def deselectAll(self):
         """Deselect all the IDs."""
@@ -222,12 +241,21 @@ class ZarrLayer():
 
         if self.is_labels:
             zarr_crop = self.zarr[z, ymin:ymax, xmin:xmax]
-            # generate all labels
+            # color each label the way autoseg import colors its trace, so the
+            # overlay preview matches the imported objects exactly. id 0 is
+            # background (not a segment); keep it the neutral gray the previous
+            # colorize(0) produced so the overlay background is unchanged.
+            # Imported locally: the autoseg package imports conversions, which
+            # imports backend.view -- a module-level import here would form a
+            # circular import while backend.view is still initializing.
+            from PyReconstruct.modules.backend.autoseg.palette import (
+                palette_color_array,
+            )
+            palette = self.series.getOption("autoseg_color_palette") or None
+            seed = self.series.getOption("autoseg_color_seed") or 0
             zarr_crop_colors = np.ascontiguousarray(
-                np.moveaxis(
-                    np.array(
-                        colorize(zarr_crop), dtype=np.uint8
-                    ), 0, -1
+                palette_color_array(
+                    zarr_crop, palette, seed, background=(100, 100, 100)
                 )
             )
             im_crop = QImage(

--- a/PyReconstruct/modules/datatypes/default_settings.py
+++ b/PyReconstruct/modules/datatypes/default_settings.py
@@ -73,6 +73,14 @@ default_settings = {
     "flag_color": [255, 0, 0],  # MFO
     "palette_inc_all": True,
 
+    # autoseg import trace colors
+    # Colors for autoseg-imported traces are chosen from a curated,
+    # grayscale-visible palette, mapped deterministically from each label id
+    # (see modules/backend/autoseg/palette.py). Leave the palette empty to use
+    # the shipped default; bump the seed to reshuffle the id -> color mapping.
+    "autoseg_color_palette": [],  # list of [R, G, B]; [] = built-in default
+    "autoseg_color_seed": 0,
+
     # shortcuts 
     "alloptions_act": "Shift+O",
     "flicker_act": "/",

--- a/PyReconstruct/modules/gui/dialog/all_options.py
+++ b/PyReconstruct/modules/gui/dialog/all_options.py
@@ -15,6 +15,7 @@ from PySide6.QtGui import (
 )
 from .quick_dialog import QuickDialog
 from .backup import BackupDialog
+from .autoseg_palette import AutosegColorsWidget
 
 from PyReconstruct.modules.datatypes import Series
 
@@ -87,6 +88,7 @@ class AllOptionsDialog(QDialog):
                 ["show_flags"],
                 ["fill_opacity"],
                 ["find_zoom"],
+                ["autoseg_colors"],
                 ["smoothing_3D"]
             ],
             "User/Series": [
@@ -328,6 +330,10 @@ class AllOptionsDialog(QDialog):
         def setOption(response):
             self.series.setOption("find_zoom", response[0])
         self.addOptionWidget("find_zoom", structure, setOption)
+
+        # autoseg import colors (seed + editable palette)
+        autoseg_widget = AutosegColorsWidget(self, self.series, use_defaults)
+        self.addOptionWidget("autoseg_colors", autoseg_widget)
 
         # user
         structure = [

--- a/PyReconstruct/modules/gui/dialog/autoseg_palette.py
+++ b/PyReconstruct/modules/gui/dialog/autoseg_palette.py
@@ -1,0 +1,254 @@
+"""Editor for the autoseg-import color palette (Series > Options > View).
+
+Autoseg import colors each imported trace from a curated whitelist, mapped
+deterministically from the label id (see modules/backend/autoseg/palette.py).
+The whitelist ships CVD-safe by default, but issue #96 asks that the user be
+able to adjust it. This widget backs the ``autoseg_color_palette`` option: it
+shows the palette as clickable color swatches, lets the user add/remove/recolor
+them, and offers a one-click reset to the shipped color-blind-safe default.
+
+It is added to the options dialog as a plain composite widget (the same pattern
+as BackupDialog) because a dynamic, growable swatch grid does not fit the static
+quick_dialog structure tuples. Like every options widget it exposes
+``accept(close=False)`` (validate) and ``set()`` (commit), which
+AllOptionsDialog calls on OK.
+
+Note on determinism: import indexes the palette by ``hash(id) % len(palette)``,
+so changing the *number* of colors reshuffles every id -> color assignment (not
+just the colors that changed). That is inherent to length-based indexing and is
+the same knob the color seed offers; it only affects future imports and the live
+preview, never traces whose colors were already baked in at a past import.
+"""
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QColorDialog,
+    QApplication,
+)
+from PySide6.QtGui import QColor, QPixmap, QIcon, QPainter, QPalette
+from PySide6.QtCore import QSize, Qt
+
+from .helper import resizeLineEdit
+from PyReconstruct.modules.backend.autoseg.palette import DEFAULT_AUTOSEG_PALETTE
+from PyReconstruct.modules.gui.utils import notify
+
+# A palette of one color makes every label id the same color and leaves the seed
+# and "Shuffle colors" button with nothing to reshuffle (next_shuffle_seed no-ops
+# below two colors). Two is the smallest palette for which the whole color
+# machinery is still meaningful, so it is the enforced floor. Distinctness beyond
+# that (avoiding near-duplicate or hard-to-see colors) is left to the user, per
+# the maintainer's intent.
+MIN_PALETTE_COLORS = 2
+
+_SWATCH_SIZE = QSize(56, 28)
+
+
+def normalize_palette(colors):
+    """Return the value to persist for ``autoseg_color_palette``.
+
+    Store ``[]`` (meaning "use the shipped default") when the edited list matches
+    DEFAULT_AUTOSEG_PALETTE exactly, so a user who never customizes keeps
+    tracking the curated default even if it changes in a future release.
+    Otherwise store the explicit list of ``[R, G, B]`` integer lists -- the
+    format ``palette_color`` and the preview already consume.
+
+        Params:
+            colors (list): list of (R, G, B) sequences
+        Returns:
+            (list): [] when equal to the default, else a list of [R, G, B] lists
+    """
+    as_tuples = [tuple(int(v) for v in c) for c in colors]
+    if as_tuples == [tuple(c) for c in DEFAULT_AUTOSEG_PALETTE]:
+        return []
+    return [[int(v) for v in c] for c in as_tuples]
+
+
+def _swatch_icon(rgb):
+    """Build a filled color-swatch icon for a palette entry."""
+    pixmap = QPixmap(_SWATCH_SIZE)
+    pixmap.fill(QColor(int(rgb[0]), int(rgb[1]), int(rgb[2])))
+    return QIcon(pixmap)
+
+
+class AutosegColorsWidget(QWidget):
+
+    def __init__(self, parent, series, use_defaults=False):
+        """Create the autoseg import-colors editor.
+
+            Params:
+                parent (QWidget): the parent widget
+                series (Series): the series whose options are edited
+                use_defaults (bool): show the shipped defaults instead of the
+                    stored values (Reset Defaults in the options dialog)
+        """
+        super().__init__(parent)
+        self.series = series
+
+        stored = series.getOption("autoseg_color_palette", use_defaults) or []
+        # An empty option means "use the built-in default"; show that default so
+        # the user edits a concrete starting palette rather than a blank list.
+        source = stored if stored else DEFAULT_AUTOSEG_PALETTE
+        self.colors = [[int(v) for v in c] for c in source]
+
+        seed = series.getOption("autoseg_color_seed", use_defaults) or 0
+        self._seed = int(seed)
+
+        vlayout = QVBoxLayout()
+
+        header = QLabel("Autoseg import colors", self)
+        f = header.font()
+        f.setBold(True)
+        header.setFont(f)
+        vlayout.addWidget(header)
+
+        desc = QLabel(
+            "Imported autoseg traces are colored from this palette, chosen\n"
+            "deterministically per label id. The default palette is color-blind\n"
+            "safe and readable on grayscale images.",
+            self,
+        )
+        vlayout.addWidget(desc)
+
+        # seed row
+        seed_row = QHBoxLayout()
+        seed_row.addWidget(QLabel("Color seed (same seed gives the same colors):", self))
+        self.seed_edit = QLineEdit(str(self._seed), self)
+        resizeLineEdit(self.seed_edit, "000000")
+        seed_row.addWidget(self.seed_edit)
+        seed_row.addStretch()
+        vlayout.addLayout(seed_row)
+
+        seed_hint = QLabel(
+            'The "Shuffle colors" button on the zarr import overlay updates this '
+            "seed;\nset a specific number to reproduce a past run.",
+            self,
+        )
+        vlayout.addWidget(seed_hint)
+
+        # swatch grid: click (or Edit) a swatch to recolor it
+        self.list = QListWidget(self)
+        self.list.setViewMode(QListWidget.IconMode)
+        self.list.setIconSize(_SWATCH_SIZE)
+        self.list.setResizeMode(QListWidget.Adjust)
+        self.list.setMovement(QListWidget.Static)
+        self.list.setSpacing(4)
+        self.list.setSelectionMode(QListWidget.SingleSelection)
+        self.list.setMaximumHeight(150)
+        self.list.itemDoubleClicked.connect(self._edit_selected)
+        self.list.currentRowChanged.connect(lambda _: self._update_buttons())
+        vlayout.addWidget(self.list)
+
+        # controls
+        btn_row = QHBoxLayout()
+        add_btn = QPushButton("Add", self)
+        add_btn.clicked.connect(self._add_color)
+        self.edit_btn = QPushButton("Edit", self)
+        self.edit_btn.clicked.connect(self._edit_selected)
+        self.remove_btn = QPushButton("Remove", self)
+        self.remove_btn.clicked.connect(self._remove_selected)
+        reset_btn = QPushButton("Reset to default", self)
+        reset_btn.clicked.connect(self._reset_default)
+        btn_row.addWidget(add_btn)
+        btn_row.addWidget(self.edit_btn)
+        btn_row.addWidget(self.remove_btn)
+        btn_row.addStretch()
+        btn_row.addWidget(reset_btn)
+        vlayout.addLayout(btn_row)
+
+        self.setLayout(vlayout)
+        self._rebuild()
+
+    # --- palette editing -----------------------------------------------------
+
+    def _rebuild(self):
+        """Repopulate the swatch grid from self.colors."""
+        self.list.clear()
+        for rgb in self.colors:
+            item = QListWidgetItem(self.list)
+            item.setIcon(_swatch_icon(rgb))
+            item.setToolTip("rgb({}, {}, {})".format(*rgb))
+        self._update_buttons()
+
+    def _update_buttons(self):
+        has_sel = self.list.currentRow() >= 0
+        self.edit_btn.setEnabled(has_sel)
+        # keep the palette at or above the floor
+        self.remove_btn.setEnabled(has_sel and len(self.colors) > MIN_PALETTE_COLORS)
+
+    def _pick_color(self, initial):
+        """Open QColorDialog; return an [R, G, B] list or None if cancelled."""
+        color = QColorDialog.getColor(QColor(*initial), self)
+        if color.isValid():
+            return [color.red(), color.green(), color.blue()]
+        return None
+
+    def _add_color(self):
+        rgb = self._pick_color((255, 255, 255))
+        if rgb is None:
+            return
+        self.colors.append(rgb)
+        self._rebuild()
+        self.list.setCurrentRow(len(self.colors) - 1)
+
+    def _edit_selected(self, *args):
+        row = self.list.currentRow()
+        if row < 0:
+            return
+        rgb = self._pick_color(self.colors[row])
+        if rgb is None:
+            return
+        self.colors[row] = rgb
+        self._rebuild()
+        self.list.setCurrentRow(row)
+
+    def _remove_selected(self):
+        row = self.list.currentRow()
+        if row < 0:
+            return
+        if len(self.colors) <= MIN_PALETTE_COLORS:
+            notify(f"The palette must keep at least {MIN_PALETTE_COLORS} colors.")
+            return
+        del self.colors[row]
+        self._rebuild()
+
+    def _reset_default(self):
+        self.colors = [[int(v) for v in c] for c in DEFAULT_AUTOSEG_PALETTE]
+        self._rebuild()
+
+    # --- options-dialog protocol (accept -> set) -----------------------------
+
+    def accept(self, close=True):
+        """Validate the inputs. Called by AllOptionsDialog before set()."""
+        text = self.seed_edit.text().strip()
+        if not text:
+            self._seed = 0
+        else:
+            try:
+                self._seed = int(text)
+            except ValueError:
+                notify("Please enter a whole number for the color seed.")
+                return False
+        if len(self.colors) < MIN_PALETTE_COLORS:
+            notify(f"The palette must keep at least {MIN_PALETTE_COLORS} colors.")
+            return False
+        return True
+
+    def set(self):
+        """Commit the seed and palette to the series options."""
+        self.series.setOption("autoseg_color_seed", self._seed)
+        self.series.setOption("autoseg_color_palette", normalize_palette(self.colors))
+
+    # --- cosmetic border, matching the sibling OptionWidgets -----------------
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        painter = QPainter(self)
+        painter.setPen(QApplication.palette().color(QPalette.WindowText))
+        painter.drawRect(self.rect().adjusted(0, 0, -1, -1))

--- a/PyReconstruct/modules/gui/main/field_widget_6_paint.py
+++ b/PyReconstruct/modules/gui/main/field_widget_6_paint.py
@@ -12,7 +12,7 @@ from PySide6.QtGui import (
     QFont,
 )
 
-from PyReconstruct.modules.calc import colorize
+from PyReconstruct.modules.backend.autoseg.palette import palette_color
 from PyReconstruct.modules.backend.view import drawArrow
 from PyReconstruct.modules.gui.utils import drawOutlinedText
 from PyReconstruct.modules.datatypes import Flag, Trace
@@ -197,7 +197,11 @@ class FieldWidgetPaint(FieldWidgetMouse):
                 # prioritize showing label name
                 if label_id is not None:
                     pos = self.mouse_x, self.mouse_y
-                    c = colorize(label_id)
+                    c = palette_color(
+                        label_id,
+                        self.series.getOption("autoseg_color_palette") or None,
+                        self.series.getOption("autoseg_color_seed") or 0,
+                    )
                     drawOutlinedText(
                         field_painter,
                         *pos,

--- a/PyReconstruct/modules/gui/main/main_window.py
+++ b/PyReconstruct/modules/gui/main/main_window.py
@@ -2264,7 +2264,35 @@ class MainWindow(QMainWindow):
         
     #     self.field.zarr_layer.mergeLabels()
     #     self.field.generateView()
-    
+
+    def shuffleAutosegColors(self):
+        """Re-roll the autoseg import color arrangement and refresh the preview.
+
+        Backs the "Shuffle colors" button on the zarr import overlay. Picks a
+        new color seed (guaranteed to produce a different arrangement) and
+        regenerates the field view, which re-reads the seed and recolors the
+        label overlay in place -- so the user sees the new colors immediately
+        and the eventual import bakes in exactly those colors. Only the live
+        preview and future imports are affected; traces imported earlier keep
+        their already-assigned colors.
+        """
+        from PyReconstruct.modules.backend.autoseg.palette import next_shuffle_seed
+
+        current = self.series.getOption("autoseg_color_seed") or 0
+        palette = self.series.getOption("autoseg_color_palette") or None
+        # Enforce the "always reshuffles" guarantee over the labels actually
+        # visible on this section, not a fixed 1..63 range: with only a few
+        # labels on screen a new seed could recolor ids the user can't see and
+        # leave the visible ones unchanged (a no-op click). Fall back to the
+        # default range when the overlay can't supply present ids.
+        zarr_layer = self.field.zarr_layer
+        present_ids = zarr_layer.getPresentIds() if zarr_layer else None
+        self.series.setOption(
+            "autoseg_color_seed",
+            next_shuffle_seed(current, palette, ids=present_ids)
+        )
+        self.field.generateView()
+
     def hideSeriesTraces(self, hidden=True):
         """Hide or unhide all traces in the entire series.
         

--- a/PyReconstruct/modules/gui/palette/zarr_palette.py
+++ b/PyReconstruct/modules/gui/palette/zarr_palette.py
@@ -31,22 +31,38 @@ class ZarrPalette():
         self.cb.currentTextChanged.connect(self.changeGroup)
         self.cb.show()
 
+        # "Shuffle colors" reshuffles the preview colors; a one-line caption
+        # states plainly what the button does and that the import keeps what
+        # the preview shows. Both are shown only for segmentation groups (see
+        # changeGroup), alongside "Import Contours".
+        self.shuffle_bttn = QPushButton(self.mainwindow, text="Shuffle colors")
+        self.shuffle_bttn.resize(self.shuffle_bttn.sizeHint())
+        self.shuffle_bttn.clicked.connect(self.mainwindow.shuffleAutosegColors)
+        self.shuffle_bttn.hide()
+
+        self.caption = OutlinedLabel(self.mainwindow)
+        self.caption.setText("Shuffle recolors the preview; import keeps what you see.")
+        self.caption.setFont(QFont("Courier New", 10))
+        self.caption.resize(self.caption.sizeHint())
+        self.caption.hide()
+
         self.bttn = QPushButton(self.mainwindow, text="Import Contours")
         self.bttn.resize(self.bttn.sizeHint())
         self.bttn.clicked.connect(lambda : self.mainwindow.importLabels(all=True))
         self.bttn.hide()
 
         self.placeWidgets()
-    
+
     def placeWidgets(self):
         """Place the widgets in the correct locations."""
         y = (
-            self.mainwindow.field.y() + self.mainwindow.field.height() - 
+            self.mainwindow.field.y() + self.mainwindow.field.height() -
             (15 + self.lbl.height() + self.cb.height())
         )
         if self.bttn.isVisible():
-            y -= (5 + self.bttn.height())
-            widgets = (self.lbl, self.cb, self.bttn)
+            y -= (5 + self.caption.height() + 5 + self.shuffle_bttn.height()
+                  + 5 + self.bttn.height())
+            widgets = (self.lbl, self.cb, self.caption, self.shuffle_bttn, self.bttn)
         else:
             widgets = (self.lbl, self.cb)
 
@@ -61,15 +77,16 @@ class ZarrPalette():
             Params:
                 group_name (str): the name of the group to change to
         """
-        if group_name.startswith("seg"):
-            self.bttn.show()
-        else:
-            self.bttn.hide()
+        show = group_name.startswith("seg")
+        for w in (self.bttn, self.shuffle_bttn, self.caption):
+            w.setVisible(show)
         self.placeWidgets()
         self.mainwindow.setLayerGroup(group_name)
-    
+
     def close(self):
         """Close all widgets."""
         self.lbl.close()
         self.cb.close()
+        self.caption.close()
+        self.shuffle_bttn.close()
         self.bttn.close()

--- a/tests/test_autoseg_color_options.py
+++ b/tests/test_autoseg_color_options.py
@@ -1,0 +1,16 @@
+"""The autoseg color options must be declared so the options dialog and the
+converter can read/write them (seed = the re-roll escape hatch)."""
+
+from PyReconstruct.modules.datatypes.default_settings import default_settings
+
+
+def test_autoseg_color_seed_is_declared_as_int():
+    assert "autoseg_color_seed" in default_settings
+    assert isinstance(default_settings["autoseg_color_seed"], int)
+
+
+def test_autoseg_color_palette_is_declared_as_list():
+    # empty by default -> converter falls back to the built-in curated palette
+    assert "autoseg_color_palette" in default_settings
+    assert isinstance(default_settings["autoseg_color_palette"], list)
+    assert default_settings["autoseg_color_palette"] == []

--- a/tests/test_autoseg_import_colors.py
+++ b/tests/test_autoseg_import_colors.py
@@ -1,0 +1,185 @@
+"""The autoseg *import* path must take its trace colors from the palette.
+
+``tests/test_autoseg_palette.py`` proves the palette itself is legible against
+grayscale, CVD-safe, and deterministic. It does not prove that autoseg import
+actually *uses* it -- which is the whole point of the feature. This module
+covers that seam: it drives ``conversions.importSection`` over a small real
+zarr and asserts every trace it creates is colored from the approved list, at
+exactly the color ``palette_color`` specifies.
+
+Without this, reverting the one line in ``importSection`` back to the old
+random ``colorize(id)`` leaves the rest of the suite green.
+"""
+import numpy as np
+import pytest
+
+zarr = pytest.importorskip("zarr")
+
+from PyReconstruct.modules.backend.autoseg import conversions
+from PyReconstruct.modules.backend.autoseg.palette import (
+    DEFAULT_AUTOSEG_PALETTE,
+    palette_color,
+)
+
+
+SNUM = 0
+LABEL_GROUP = "labels_test"
+# Ids placed in the label plane. Small distinct blobs, none of them 0
+# (background), chosen to land on more than one palette entry.
+LABEL_IDS = (1, 2, 3, 4, 5, 7, 11, 13)
+
+
+class _SectionStub:
+    """Collects the traces import would have added; no disk, no Qt."""
+
+    def __init__(self):
+        self.added = []
+        self.saved = 0
+        self.n = SNUM
+        self.contours = {}
+
+    def addTrace(self, trace, *args, **kwargs):
+        self.added.append(trace)
+
+    def save(self):
+        self.saved += 1
+
+
+class _GroupsStub:
+    def __init__(self):
+        self.adds = []
+
+    def add(self, group, name):
+        self.adds.append((group, name))
+
+
+class _SeriesStub:
+    """Minimal series: the two color options, a section, and object groups."""
+
+    def __init__(self, palette=None, seed=0):
+        self._palette = [] if palette is None else palette
+        self._seed = seed
+        self.section = _SectionStub()
+        self.object_groups = _GroupsStub()
+
+    def getOption(self, name, *args, **kwargs):
+        if name == "autoseg_color_palette":
+            return self._palette
+        if name == "autoseg_color_seed":
+            return self._seed
+        raise KeyError(name)
+
+    def loadSection(self, snum):
+        return self.section
+
+
+def _make_zarr(tmp_path):
+    """A minimal neuroglancer-style zarr importSection can actually read."""
+    root = zarr.open(str(tmp_path / "test.zarr"), mode="w")
+
+    # One 64x64 label plane holding a small square per id.
+    plane = np.zeros((1, 64, 64), dtype=np.uint32)
+    for i, label_id in enumerate(LABEL_IDS):
+        r = (i // 4) * 16 + 2
+        c = (i % 4) * 16 + 2
+        plane[0, r:r + 10, c:c + 10] = label_id
+
+    labels = root.create_dataset(LABEL_GROUP, data=plane, overwrite=True)
+    labels.attrs["resolution"] = [50, 4, 4]
+    labels.attrs["offset"] = [0, 0, 0]
+
+    raw = root.create_dataset(
+        "raw", data=np.zeros((1, 64, 64), dtype=np.uint8), overwrite=True
+    )
+    raw.attrs["resolution"] = [50, 4, 4]
+    raw.attrs["offset"] = [0, 0, 0]
+    raw.attrs["window"] = [0.0, 0.0, 1.0, 1.0]
+    raw.attrs["sections"] = [SNUM]
+    raw.attrs["true_mag"] = 0.004
+    # identity transform for the one section
+    raw.attrs["alignment"] = {str(SNUM): [1, 0, 0, 0, 1, 0]}
+
+    return root
+
+
+def _run_import(tmp_path, series):
+    data_zg = _make_zarr(tmp_path)
+    conversions.importSection(data_zg, LABEL_GROUP, SNUM, series)
+    assert series.section.added, "import produced no traces"
+    return series.section.added
+
+
+def test_import_colors_come_from_the_approved_list(tmp_path):
+    """Every imported trace is colored from the whitelist -- the #96 ask."""
+    series = _SeriesStub()
+    traces = _run_import(tmp_path, series)
+
+    whitelist = {tuple(c) for c in DEFAULT_AUTOSEG_PALETTE}
+    for trace in traces:
+        assert tuple(trace.color) in whitelist, (
+            f"{trace.name} got off-palette color {tuple(trace.color)}"
+        )
+
+
+def test_import_color_matches_palette_color_for_the_label_id(tmp_path):
+    """Import must assign exactly what palette_color specifies for that id."""
+    series = _SeriesStub()
+    traces = _run_import(tmp_path, series)
+
+    seen = set()
+    for trace in traces:
+        label_id = int(trace.name.removeprefix("autoseg_"))
+        seen.add(label_id)
+        assert tuple(trace.color) == palette_color(label_id)
+    assert seen, "no autoseg-named traces were created"
+
+
+def test_import_never_assigns_a_near_gray_or_dark_color(tmp_path):
+    """The legibility guarantee, asserted on real import output.
+
+    A grayscale EM background camouflages exactly the achromatic and near-black
+    colors, which is what the issue reported. Mirrors the palette-level bound.
+    """
+    series = _SeriesStub()
+    traces = _run_import(tmp_path, series)
+
+    for trace in traces:
+        r, g, b = (int(c) for c in trace.color)
+        assert max(r, g, b) - min(r, g, b) >= 60, (
+            f"{trace.name} color {(r, g, b)} is too close to gray"
+        )
+        assert max(r, g, b) >= 100, (
+            f"{trace.name} color {(r, g, b)} is too dark"
+        )
+
+
+def test_import_honors_a_custom_palette(tmp_path):
+    """A user-adjusted palette (series option) drives import colors."""
+    custom = [(11, 22, 33), (200, 100, 50)]
+    series = _SeriesStub(palette=custom)
+    traces = _run_import(tmp_path, series)
+
+    custom_set = {tuple(c) for c in custom}
+    for trace in traces:
+        label_id = int(trace.name.removeprefix("autoseg_"))
+        assert tuple(trace.color) in custom_set
+        assert tuple(trace.color) == palette_color(label_id, custom, 0)
+
+
+def test_import_honors_the_color_seed(tmp_path):
+    """Changing the seed (what Shuffle colors does) changes import colors."""
+    traces_a = _run_import(tmp_path / "a", _SeriesStub(seed=0))
+    traces_b = _run_import(tmp_path / "b", _SeriesStub(seed=12345))
+
+    by_id_a = {t.name: tuple(t.color) for t in traces_a}
+    by_id_b = {t.name: tuple(t.color) for t in traces_b}
+    assert by_id_a.keys() == by_id_b.keys()
+    assert by_id_a != by_id_b, "seed change did not affect import colors"
+
+
+def test_import_is_deterministic_across_runs(tmp_path):
+    """Same ids + same seed -> same colors, so an object is one color
+    on every section it appears on."""
+    a = {t.name: tuple(t.color) for t in _run_import(tmp_path / "a", _SeriesStub())}
+    b = {t.name: tuple(t.color) for t in _run_import(tmp_path / "b", _SeriesStub())}
+    assert a == b

--- a/tests/test_autoseg_palette.py
+++ b/tests/test_autoseg_palette.py
@@ -1,0 +1,331 @@
+"""Tests for the autoseg trace-color palette.
+
+Verifies that autoseg import assigns colors from a curated, grayscale-visible
+whitelist, deterministically mapped from each label id.
+"""
+
+import pytest
+
+from PyReconstruct.modules.backend.autoseg.palette import (
+    DEFAULT_AUTOSEG_PALETTE,
+    palette_color,
+    palette_color_array,
+    next_shuffle_seed,
+)
+
+# Thresholds separating a usable overlay color from the grayscale background.
+# chroma = max(RGB) - min(RGB): distance from the achromatic ("gray") axis.
+# value  = max(RGB): overall brightness (guards against near-black tones).
+MIN_CHROMA = 60
+MIN_VALUE = 120
+
+# Sampling range for id -> color assertions.
+SAMPLE_IDS = range(1, 5000)
+
+
+def _chroma(color):
+    return max(color) - min(color)
+
+
+def _value(color):
+    return max(color)
+
+
+# --- palette content -------------------------------------------------------
+
+
+def test_palette_is_nonempty_and_reasonable_size():
+    assert 8 <= len(DEFAULT_AUTOSEG_PALETTE) <= 24
+
+
+def test_palette_entries_are_rgb_int_triples_in_range():
+    for color in DEFAULT_AUTOSEG_PALETTE:
+        assert len(color) == 3
+        for channel in color:
+            assert isinstance(channel, int)
+            assert 0 <= channel <= 255
+
+
+def test_palette_has_no_near_gray_or_dark_colors():
+    """Every whitelist color must sit off the gray axis and not be too dark."""
+    for color in DEFAULT_AUTOSEG_PALETTE:
+        assert _chroma(color) >= MIN_CHROMA, f"{color} is too close to gray"
+        assert _value(color) >= MIN_VALUE, f"{color} is too dark"
+
+
+def test_palette_entries_are_distinct():
+    assert len(set(DEFAULT_AUTOSEG_PALETTE)) == len(DEFAULT_AUTOSEG_PALETTE)
+
+
+# --- deterministic id -> color mapping -------------------------------------
+
+
+def test_mapping_is_deterministic():
+    """Same id (and seed) always yields the same color."""
+    for label_id in SAMPLE_IDS:
+        assert palette_color(label_id) == palette_color(label_id)
+
+
+def test_mapping_matches_known_reference_values():
+    """Pin the exact id -> color mapping so the hash cannot drift silently."""
+    expected = {
+        0: (240, 228, 66),
+        1: (204, 121, 167),
+        2: (86, 180, 233),
+        3: (178, 0, 0),
+        5: (0, 0, 178),
+        42: (240, 228, 66),
+        100: (51, 255, 187),
+        1000: (0, 158, 115),
+    }
+    for label_id, color in expected.items():
+        assert palette_color(label_id) == color
+
+
+def test_every_produced_color_is_from_the_whitelist():
+    whitelist = set(DEFAULT_AUTOSEG_PALETTE)
+    for seed in (0, 1, 7, 12345):
+        for label_id in SAMPLE_IDS:
+            assert palette_color(label_id, seed=seed) in whitelist
+
+
+def test_produced_colors_are_never_near_gray():
+    for label_id in SAMPLE_IDS:
+        color = palette_color(label_id)
+        assert _chroma(color) >= MIN_CHROMA
+        assert _value(color) >= MIN_VALUE
+
+
+def test_mapping_covers_whole_palette():
+    """A good hash should reach every palette entry over enough ids."""
+    seen = {palette_color(label_id) for label_id in SAMPLE_IDS}
+    assert seen == set(DEFAULT_AUTOSEG_PALETTE)
+
+
+def test_consecutive_ids_are_scattered():
+    """Consecutive label ids should not all collapse to one color."""
+    colors = [palette_color(label_id) for label_id in range(1, 13)]
+    assert len(set(colors)) >= len(DEFAULT_AUTOSEG_PALETTE) // 2
+
+
+# --- seed behavior ---------------------------------------------------------
+
+
+def test_seed_reshuffles_assignment():
+    """Changing the seed changes at least some id -> color assignments."""
+    differ = any(
+        palette_color(label_id, seed=0) != palette_color(label_id, seed=1)
+        for label_id in SAMPLE_IDS
+    )
+    assert differ
+
+
+def test_seed_is_still_deterministic():
+    for label_id in SAMPLE_IDS:
+        assert palette_color(label_id, seed=99) == palette_color(label_id, seed=99)
+
+
+# --- shuffle ("Shuffle colors" button) -------------------------------------
+#
+# The button calls next_shuffle_seed to pick a new seed. Each click must
+# visibly change the id -> color arrangement, and the result must stay a plain
+# deterministic seed so preview==import still holds.
+
+
+def _arrangement(seed, palette=None):
+    return [palette_color(i, palette, seed) for i in range(1, 64)]
+
+
+def test_shuffle_changes_the_arrangement():
+    """A shuffle must produce a genuinely different id -> color mapping."""
+    import random
+    seed = 0
+    for _ in range(25):  # simulate repeated clicks
+        new_seed = next_shuffle_seed(seed, rng=random.Random(_))
+        assert _arrangement(new_seed) != _arrangement(seed)
+        seed = new_seed
+
+
+def test_shuffle_returns_plain_int_seed():
+    """Result is a concrete non-negative int -> stays deterministic/persistable."""
+    import random
+    new_seed = next_shuffle_seed(0, rng=random.Random(1))
+    assert isinstance(new_seed, int)
+    assert new_seed >= 0
+    # and it drives the same deterministic mapping every time it is reused
+    assert _arrangement(new_seed) == _arrangement(new_seed)
+
+
+def test_shuffle_is_reproducible_with_seeded_rng():
+    """Injecting the same rng yields the same choice (testability/determinism)."""
+    import random
+    a = next_shuffle_seed(0, rng=random.Random(1234))
+    b = next_shuffle_seed(0, rng=random.Random(1234))
+    assert a == b
+
+
+def test_shuffle_noop_on_single_color_palette():
+    """No reshuffle exists for a <2 color palette; the seed is left unchanged."""
+    import random
+    assert next_shuffle_seed(5, palette=[(1, 2, 3)], rng=random.Random(0)) == 5
+
+
+def test_shuffle_changes_the_visible_ids_when_supplied():
+    """When present ids are supplied, the guarantee applies to THEM: the
+    visible ids' colors must change on every click, not just some fixed 1..63
+    fingerprint (which could move while the on-screen labels do not)."""
+    import random
+    visible = [3, 17, 42]
+
+    def vis_arr(seed):
+        return [palette_color(i, DEFAULT_AUTOSEG_PALETTE, seed) for i in visible]
+
+    seed = 0
+    for _ in range(25):  # simulate repeated clicks
+        new_seed = next_shuffle_seed(seed, ids=visible, rng=random.Random(_))
+        assert vis_arr(new_seed) != vis_arr(seed)
+        seed = new_seed
+
+
+def test_shuffle_empty_or_none_ids_fall_back_to_default_range():
+    """Empty/None ids -> the default 1..63 fingerprint (still reshuffles)."""
+    import random
+    a = next_shuffle_seed(0, ids=[], rng=random.Random(1))
+    b = next_shuffle_seed(0, ids=None, rng=random.Random(1))
+    c = next_shuffle_seed(0, rng=random.Random(1))
+    assert a == b == c
+    assert _arrangement(a) != _arrangement(0)
+
+
+def test_shuffle_ids_drop_background_zero():
+    """id 0 (background) is dropped from the fingerprint; [0] behaves as empty
+    and falls back to the default range."""
+    import random
+    a = next_shuffle_seed(0, ids=[0], rng=random.Random(7))
+    b = next_shuffle_seed(0, rng=random.Random(7))
+    assert a == b
+
+
+# --- override / fallback ---------------------------------------------------
+
+
+def test_empty_or_none_palette_falls_back_to_default():
+    """An empty override (the shipped option default) uses the built-in palette."""
+    assert palette_color(3, palette=None) == palette_color(3)
+    assert palette_color(3, palette=[]) == palette_color(3)
+
+
+def test_custom_palette_is_respected():
+    custom = [(1, 2, 3), (4, 5, 6)]
+    for label_id in SAMPLE_IDS:
+        assert palette_color(label_id, palette=custom) in custom
+
+
+def test_return_type_is_int_tuple():
+    color = palette_color(7)
+    assert isinstance(color, tuple)
+    assert all(isinstance(channel, int) for channel in color)
+
+
+# --- color-vision-deficiency (CVD) distinguishability ----------------------
+#
+# Simulate deuteranopia / protanopia / tritanopia with the Machado et al. (2009)
+# severity-1.0 matrices (applied in linear RGB) and require every pair of
+# palette colors to stay perceptually separated (CIEDE2000) under each
+# deficiency. This guards against a future edit reintroducing a CVD collision
+# (e.g. the yellow/lime pair that merges under red-green deficiency).
+
+# Minimum acceptable pairwise CIEDE2000 separation. The shipped palette holds a
+# worst case of ~10.9 under tritanopia; 9.0 leaves margin while still catching a
+# regression that pulls two colors together.
+MIN_CVD_DELTA_E = 9.0
+MIN_NORMAL_DELTA_E = 10.0
+
+_MACHADO = {
+    "protan": [[0.152286, 1.052583, -0.204868],
+               [0.114503, 0.786281, 0.099216],
+               [-0.003882, -0.048116, 1.051998]],
+    "deutan": [[0.367322, 0.860646, -0.227968],
+               [0.280085, 0.672501, 0.047413],
+               [-0.011820, 0.042940, 0.968881]],
+    "tritan": [[1.255528, -0.076749, -0.178779],
+               [-0.078411, 0.930809, 0.147602],
+               [0.004733, 0.691367, 0.303900]],
+}
+
+
+def _simulate(rgb255, kind, np):
+    c = np.asarray(rgb255, float) / 255.0
+    if kind == "normal":
+        return c
+    lin = np.where(c <= 0.04045, c / 12.92, ((c + 0.055) / 1.055) ** 2.4)
+    sim = np.clip(np.asarray(_MACHADO[kind]) @ lin, 0.0, 1.0)
+    return np.where(sim <= 0.0031308, sim * 12.92,
+                    1.055 * (sim ** (1 / 2.4)) - 0.055)
+
+
+def _min_pairwise_delta_e(kind):
+    import numpy as np
+    from itertools import combinations
+    from skimage.color import rgb2lab, deltaE_ciede2000
+
+    labs = []
+    for color in DEFAULT_AUTOSEG_PALETTE:
+        sim = _simulate(color, kind, np).reshape(1, 1, 3)
+        labs.append(rgb2lab(sim))
+    return min(
+        # deltaE_ciede2000 on (1,1,3) Lab inputs returns a (1,1) array; numpy
+        # >= 2.0 refuses float() on a non-0-d array, so flatten to a scalar
+        # (robust across numpy/skimage versions).
+        float(np.ravel(deltaE_ciede2000(a, b))[0]) for a, b in combinations(labs, 2)
+    )
+
+
+# --- vectorized overlay mapping ---------------------------------------------
+#
+# The live label overlay is colored with palette_color_array; it must produce
+# exactly the color palette_color would give each id, so the preview matches
+# the imported traces.
+
+
+def test_overlay_array_matches_scalar_mapping():
+    np = pytest.importorskip("numpy")
+    arr = np.array([[0, 1, 2, 3], [5, 42, 100, 1000]], dtype=np.int64)
+    out = palette_color_array(arr, None, seed=0, background=(100, 100, 100))
+    assert out.shape == (2, 4, 3)
+    assert out.dtype == np.uint8
+    for y in range(arr.shape[0]):
+        for x in range(arr.shape[1]):
+            lid = int(arr[y, x])
+            expected = (100, 100, 100) if lid == 0 else palette_color(lid)
+            assert tuple(int(v) for v in out[y, x]) == tuple(expected)
+
+
+def test_overlay_array_respects_background():
+    np = pytest.importorskip("numpy")
+    arr = np.zeros((3, 3), dtype=np.int64)
+    out = palette_color_array(arr, None, seed=0, background=(7, 8, 9))
+    assert (out == np.array([7, 8, 9], dtype=np.uint8)).all()
+
+
+def test_overlay_array_tracks_seed():
+    np = pytest.importorskip("numpy")
+    arr = np.array([[1, 2, 3]], dtype=np.int64)
+    a = palette_color_array(arr, None, seed=0)
+    b = palette_color_array(arr, None, seed=1)
+    assert not np.array_equal(a, b)
+
+
+@pytest.mark.parametrize("kind", ["protan", "deutan", "tritan"])
+def test_palette_is_cvd_distinguishable(kind):
+    pytest.importorskip("skimage")
+    assert _min_pairwise_delta_e(kind) >= MIN_CVD_DELTA_E
+
+
+def test_palette_is_distinguishable_to_normal_vision():
+    pytest.importorskip("skimage")
+    assert _min_pairwise_delta_e("normal") >= MIN_NORMAL_DELTA_E
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_autoseg_palette_editor.py
+++ b/tests/test_autoseg_palette_editor.py
@@ -1,0 +1,244 @@
+"""Tests for the autoseg import-colors editor (Series > Options > View).
+
+The editor backs the ``autoseg_color_palette`` / ``autoseg_color_seed`` options.
+These tests exercise its save path (accept -> set), reset-to-default, the
+minimum-color floor, and that what it persists is exactly what the import
+preview and shuffle consume -- without opening real Qt dialogs.
+"""
+import types
+
+import pytest
+
+from PyReconstruct.modules.backend.autoseg.palette import (
+    DEFAULT_AUTOSEG_PALETTE,
+    palette_color,
+)
+from PyReconstruct.modules.gui.dialog import autoseg_palette as ape
+from PyReconstruct.modules.gui.dialog.autoseg_palette import (
+    AutosegColorsWidget,
+    MIN_PALETTE_COLORS,
+    normalize_palette,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PySide6.QtWidgets import QApplication
+    return QApplication.instance() or QApplication(["test"])
+
+
+class _SeriesStub:
+    """Minimal series exposing just the option get/set the editor uses."""
+
+    def __init__(self, palette=None, seed=0):
+        self.store = {
+            "autoseg_color_palette": [] if palette is None else palette,
+            "autoseg_color_seed": seed,
+        }
+        self.writes = []
+
+    def getOption(self, name, use_defaults=False):
+        if use_defaults:
+            return {"autoseg_color_palette": [], "autoseg_color_seed": 0}[name]
+        return self.store[name]
+
+    def setOption(self, name, value):
+        self.store[name] = value
+        self.writes.append((name, value))
+
+
+def _widget(qapp, series, use_defaults=False):
+    return AutosegColorsWidget(None, series, use_defaults)
+
+
+# --- normalize_palette (pure) ----------------------------------------------
+
+
+def test_normalize_default_returns_empty():
+    # an unchanged default palette persists as [] so it keeps tracking the
+    # shipped default instead of freezing today's colors
+    assert normalize_palette([list(c) for c in DEFAULT_AUTOSEG_PALETTE]) == []
+    assert normalize_palette([tuple(c) for c in DEFAULT_AUTOSEG_PALETTE]) == []
+
+
+def test_normalize_custom_returns_list_of_lists():
+    custom = [(1, 2, 3), (4, 5, 6)]
+    assert normalize_palette(custom) == [[1, 2, 3], [4, 5, 6]]
+
+
+def test_normalize_near_default_still_persists_explicitly():
+    near = [list(c) for c in DEFAULT_AUTOSEG_PALETTE]
+    near[0] = [0, 0, 0]  # one channel changed -> no longer the default
+    out = normalize_palette(near)
+    assert out != []
+    assert out[0] == [0, 0, 0]
+
+
+# --- construction: what the editor shows -----------------------------------
+
+
+def test_empty_option_shows_default_palette(qapp):
+    w = _widget(qapp, _SeriesStub(palette=[]))
+    assert w.colors == [list(c) for c in DEFAULT_AUTOSEG_PALETTE]
+    assert w.list.count() == len(DEFAULT_AUTOSEG_PALETTE)
+
+
+def test_stored_custom_palette_is_shown(qapp):
+    custom = [[10, 20, 30], [40, 50, 60], [70, 80, 90]]
+    w = _widget(qapp, _SeriesStub(palette=custom, seed=7))
+    assert w.colors == custom
+    assert w.list.count() == 3
+    assert w.seed_edit.text() == "7"
+
+
+# --- save path (accept -> set) ---------------------------------------------
+
+
+def test_set_round_trips_custom_palette_and_seed(qapp):
+    series = _SeriesStub(palette=[], seed=0)
+    w = _widget(qapp, series)
+    w.colors = [[10, 20, 30], [40, 50, 60]]
+    w.seed_edit.setText("12345")
+    assert w.accept(close=False) is True
+    w.set()
+    assert series.store["autoseg_color_palette"] == [[10, 20, 30], [40, 50, 60]]
+    assert series.store["autoseg_color_seed"] == 12345
+
+
+def test_set_normalizes_unchanged_default_to_empty(qapp):
+    # opening on the default palette and saving without edits keeps the option []
+    series = _SeriesStub(palette=[], seed=3)
+    w = _widget(qapp, series)
+    assert w.accept(close=False) is True
+    w.set()
+    assert series.store["autoseg_color_palette"] == []
+    assert series.store["autoseg_color_seed"] == 3
+
+
+def test_saved_palette_is_consumable_by_preview_and_import(qapp):
+    """What the editor writes must be exactly what palette_color reads -- the
+    same option the live preview, shuffle and import all consume."""
+    series = _SeriesStub(palette=[], seed=0)
+    w = _widget(qapp, series)
+    custom = [[10, 20, 30], [40, 50, 60], [200, 100, 0]]
+    w.colors = [list(c) for c in custom]
+    assert w.accept(close=False) is True
+    w.set()
+    saved = series.store["autoseg_color_palette"]
+    seen = {palette_color(i, saved, series.store["autoseg_color_seed"])
+            for i in range(1, 500)}
+    assert seen  # non-empty
+    assert all(list(c) in custom for c in seen)
+
+
+# --- reset to default -------------------------------------------------------
+
+
+def test_reset_to_default_restores_cvd_palette(qapp):
+    series = _SeriesStub(palette=[[1, 1, 1], [2, 2, 2]], seed=0)
+    w = _widget(qapp, series)
+    assert w.colors == [[1, 1, 1], [2, 2, 2]]
+    w._reset_default()
+    assert w.colors == [list(c) for c in DEFAULT_AUTOSEG_PALETTE]
+    w.set()
+    # reset + save collapses back to the "use built-in default" sentinel
+    assert series.store["autoseg_color_palette"] == []
+
+
+# --- minimum-color floor ----------------------------------------------------
+
+
+def test_remove_refuses_below_minimum(qapp, monkeypatch):
+    notes = []
+    monkeypatch.setattr(ape, "notify", lambda msg: notes.append(msg))
+    w = _widget(qapp, _SeriesStub(palette=[[1, 2, 3], [4, 5, 6]]))
+    w.list.setCurrentRow(0)
+    w._remove_selected()
+    assert len(w.colors) == MIN_PALETTE_COLORS  # unchanged
+    assert notes  # user was told why
+
+
+def test_remove_button_disabled_at_minimum(qapp):
+    w = _widget(qapp, _SeriesStub(palette=[[1, 2, 3], [4, 5, 6]]))
+    w.list.setCurrentRow(0)
+    assert not w.remove_btn.isEnabled()
+
+
+def test_remove_allowed_above_minimum(qapp):
+    w = _widget(qapp, _SeriesStub(palette=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
+    w.list.setCurrentRow(1)
+    assert w.remove_btn.isEnabled()
+    w._remove_selected()
+    assert w.colors == [[1, 2, 3], [7, 8, 9]]
+
+
+def test_accept_rejects_below_minimum(qapp, monkeypatch):
+    notes = []
+    monkeypatch.setattr(ape, "notify", lambda msg: notes.append(msg))
+    w = _widget(qapp, _SeriesStub(palette=[[1, 2, 3], [4, 5, 6]]))
+    w.colors = [[1, 2, 3]]  # forced below floor
+    assert w.accept(close=False) is False
+    assert notes
+
+
+# --- seed validation --------------------------------------------------------
+
+
+def test_accept_treats_empty_seed_as_zero(qapp):
+    w = _widget(qapp, _SeriesStub(palette=[], seed=9))
+    w.seed_edit.setText("")
+    assert w.accept(close=False) is True
+    assert w._seed == 0
+
+
+def test_accept_rejects_non_integer_seed(qapp, monkeypatch):
+    notes = []
+    monkeypatch.setattr(ape, "notify", lambda msg: notes.append(msg))
+    w = _widget(qapp, _SeriesStub(palette=[], seed=0))
+    w.seed_edit.setText("not-a-number")
+    assert w.accept(close=False) is False
+    assert notes
+
+
+# --- add / edit via the color dialog (stubbed) ------------------------------
+
+
+def _stub_color(monkeypatch, rgb):
+    from PySide6.QtGui import QColor
+
+    class _C(QColor):
+        def isValid(self):
+            return rgb is not None
+
+    def fake_getColor(initial=None, parent=None, *a, **k):
+        return _C(*rgb) if rgb is not None else _C()
+
+    monkeypatch.setattr(ape.QColorDialog, "getColor", staticmethod(fake_getColor))
+
+
+def test_add_color_appends_picked_color(qapp, monkeypatch):
+    _stub_color(monkeypatch, (11, 22, 33))
+    w = _widget(qapp, _SeriesStub(palette=[[1, 2, 3], [4, 5, 6]]))
+    w._add_color()
+    assert w.colors[-1] == [11, 22, 33]
+    assert w.list.count() == 3
+
+
+def test_edit_color_replaces_selected(qapp, monkeypatch):
+    _stub_color(monkeypatch, (99, 88, 77))
+    w = _widget(qapp, _SeriesStub(palette=[[1, 2, 3], [4, 5, 6]]))
+    w.list.setCurrentRow(1)
+    w._edit_selected()
+    assert w.colors == [[1, 2, 3], [99, 88, 77]]
+
+
+def test_cancelled_color_dialog_leaves_palette_unchanged(qapp, monkeypatch):
+    _stub_color(monkeypatch, None)  # invalid -> user cancelled
+    w = _widget(qapp, _SeriesStub(palette=[[1, 2, 3], [4, 5, 6]]))
+    before = [list(c) for c in w.colors]
+    w._add_color()
+    assert w.colors == before
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Replaces random color assignment on autoseg import with a curated 12-color list.

`colorize(id)` put 13 of the first 40 label ids below saturation 60 (id 1 gave `(101,100,100)`, effectively gray on a grayscale image, which is the problem reported in #96). The curated list has none below 60, and assignment is a deterministic hash of the label id, so a label keeps one color across every section and session.

Adjustable through `Series > Options > View`, which gets a swatch-grid editor (add/edit/remove/reset, minimum two colors). An unedited palette stores as `[]`, so users who never customize keep tracking future updates to the shipped default. A "Shuffle colors" button on the zarr import overlay handles the case where two touching labels land on similar colors.

The list is derived from Okabe-Ito extended to 12 by farthest-point selection under simulated color-vision deficiency.

Not included: recoloring objects imported before the palette existed, which needs helpers this does not add, so it is a clean follow-up.

Includes tests for the palette separation, the import path's use of the approved colors, and the options editor.

Closes #96
