### PR TITLE
chore(deps): bump gitpython to 3.1.57

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "lxml==6.1.0",
     "tifffile==2024.9.20",
     "qdarkstyle==3.2.3",
-    "gitpython==3.1.50",
+    "gitpython==3.1.57",
     "certifi",
     "packaging",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PySide6==6.5.2
 cloud-volume==11.0.0
-gitpython==3.1.50
+gitpython==3.1.57
 lxml==6.1.0
 numcodecs==0.15.0
 numpy==1.24.1


### PR DESCRIPTION
Bumps `gitpython` from `3.1.50` to `3.1.57` in `requirements.txt` and `pyproject.toml`, clearing the nine advisories on that pin (fixes land across 3.1.51 through 3.1.55; 3.1.57 is current and three of the nine are follow-up fixes for earlier entries in the series).

Nothing else moves: `gitpython` is pure Python with no declared dependencies and a `>=3.7` floor. The only calls in the tree are `git.Repo()`, `head.commit.hexsha`, and `active_branch.name` in `modules/constants/repo_info.py`, and every advisory is in clone, remote, archive, diff, or config handling, so this is pin hygiene rather than a reachable fix.

Leaves `vtk==9.3.1` alone deliberately. Its three CVEs are first fixed in `9.5.1`, and bumping that pin on its own breaks the 3D scene: `VPlotter.__init__` builds `vedo.Text2D` unconditionally and vtk 9.4+ raises `TypeError: ... requires a vtkProperty2D`. It needs a matching `vedo` bump plus three transform call sites, so it wants its own change. Happy to write that up separately.

Refs #112
