### PR TITLE
feat(cleanup): add a Clean up submenu and find cross-name duplicates

### DIFF
--- a/PyReconstruct/modules/datatypes/series.py
+++ b/PyReconstruct/modules/datatypes/series.py
@@ -20,6 +20,8 @@ from .objects import Objects, SeriesObject
 from .default_settings import default_settings, default_series_settings
 from .host_tree import HostTree
 
+from PyReconstruct.modules.calc import area, lineDistance
+
 from PyReconstruct.modules.constants import (
     createHiddenDir,
     welcome_series_dir,
@@ -1376,8 +1378,12 @@ class Series():
 
         return malformed
 
-    def deleteMalformedTraces(self, records : list, series_states=None) -> list:
+    def deleteMalformedTraces(self, records : list, series_states=None, message="Deleting malformed contours...") -> list:
         """Delete specific malformed traces reported by smoothObject.
+
+        Also used by the data clean-up operations (pixel-dust / empty traces),
+        which produce records with the same schema (name, section, match); pass
+        a different ``message`` so the progress bar reads sensibly.
 
         Each record must carry the keys produced by smoothObject — in
         particular "name", "section" and "match" (a {"color", "points"}
@@ -1404,7 +1410,7 @@ class Series():
 
         deleted = []
         for snum, section in self.enumerateSections(
-            message="Deleting malformed contours...",
+            message=message,
             series_states=series_states
         ):
             removed_any = False
@@ -1442,6 +1448,332 @@ class Series():
             if round(x, 7) != sx or round(y, 7) != sy:
                 return False
         return True
+
+    @staticmethod
+    def _cleanupRecord(obj_name, snum, index, trace, reason, area=None) -> dict:
+        """Build a clean-up candidate record.
+
+        Uses the same schema smoothObject produces (so the records can be
+        deleted with deleteMalformedTraces and shown in the review dialog): a
+        "match" signature of color + 7-decimal-rounded points re-finds the exact
+        trace after the section is reloaded from disk. An optional physical
+        area (um^2) is carried for display in the pixel-dust review list.
+        """
+        num_points = len(trace.points)
+        record = {
+            "name": obj_name,
+            "section": snum,
+            "index": index,
+            "points": num_points,
+            "location": (
+                tuple(round(c, 4) for c in trace.points[0])
+                if num_points else None
+            ),
+            "reason": reason,
+            "match": {
+                "color": trace.color,
+                "points": [
+                    (round(x, 7), round(y, 7)) for x, y in trace.points
+                ],
+            },
+        }
+        if area is not None:
+            record["area"] = area
+        return record
+
+    @staticmethod
+    def _traceArea(trace, tform) -> float:
+        """Physical area (um^2) of a trace, matching the object/trace tables.
+
+        Mirrors TraceData: map the points through the section transform, then
+        run the same quantification the tables use. Open traces have no
+        enclosed area.
+        """
+        if not trace.closed or len(trace.points) < 3:
+            return 0.0
+        return abs(area(tform.map(trace.points)))
+
+    def findPixelDustTraces(self, threshold_area : float, include_locked=False) -> list:
+        """Find tiny "pixel-dust" traces at or below an area threshold.
+
+        A candidate is a CLOSED trace whose physical area (um^2, computed the
+        same way the object/trace tables report it) is greater than zero and at
+        or below ``threshold_area``. Zero-area / degenerate traces are left to
+        findEmptyTraces so the two operations stay disjoint. Open traces (lines)
+        have no enclosed area and are never pixel dust. Locked objects are
+        skipped unless ``include_locked`` is True. This only scans; nothing is
+        modified. Use deleteMalformedTraces to remove the chosen records.
+
+            Params:
+                threshold_area (float): the maximum area (um^2), inclusive
+                include_locked (bool): True to also consider locked objects
+            Returns:
+                (list): candidate records (see _cleanupRecord)
+        """
+        candidates = []
+        for snum, section in self.enumerateSections(
+            message="Scanning for pixel-dust traces...",
+        ):
+            tform = section.tform
+            for cname in section.contours:
+                if not include_locked and self.getAttr(cname, "locked"):
+                    continue
+                for index, trace in enumerate(section.contours[cname]):
+                    if not trace.closed or len(trace.points) < 3:
+                        continue
+                    trace_area = self._traceArea(trace, tform)
+                    if 0 < trace_area <= threshold_area:
+                        candidates.append(self._cleanupRecord(
+                            cname, snum, index, trace,
+                            reason=(
+                                f"Area {trace_area:.6g} um^2 "
+                                f"(<= {threshold_area:.6g})"
+                            ),
+                            area=trace_area,
+                        ))
+        return candidates
+
+    def findEmptyTraces(self, include_locked=False) -> list:
+        """Find empty / degenerate traces (no meaningful geometry).
+
+        A trace is empty when it encloses/spans nothing: no points, a closed
+        trace with zero area (fewer than 3 points or fully collinear/coincident
+        points), or an open trace with zero length (all points coincident).
+        These are unambiguous to remove. Locked objects are skipped unless
+        ``include_locked`` is True. Scans only; use deleteMalformedTraces to
+        remove the chosen records.
+
+            Params:
+                include_locked (bool): True to also consider locked objects
+            Returns:
+                (list): candidate records (see _cleanupRecord)
+        """
+        candidates = []
+        for snum, section in self.enumerateSections(
+            message="Scanning for empty traces...",
+        ):
+            tform = section.tform
+            for cname in section.contours:
+                if not include_locked and self.getAttr(cname, "locked"):
+                    continue
+                for index, trace in enumerate(section.contours[cname]):
+                    npts = len(trace.points)
+                    if npts == 0:
+                        reason = "No points"
+                    elif trace.closed:
+                        if self._traceArea(trace, tform) == 0:
+                            reason = "Closed trace enclosing zero area"
+                        else:
+                            continue
+                    else:
+                        length = lineDistance(
+                            tform.map(trace.points), closed=False
+                        )
+                        if length == 0:
+                            reason = "Open trace of zero length"
+                        else:
+                            continue
+                    candidates.append(self._cleanupRecord(
+                        cname, snum, index, trace, reason=reason,
+                    ))
+        return candidates
+
+    ## A pair of traces is only worth measuring an overlap ratio for if that
+    ## ratio could possibly clear the threshold. _duplicatePairs proves a
+    ## ceiling on the ratio from quantities it already has, and skips the pair
+    ## when the ceiling falls this far below the threshold. The ceiling bounds
+    ## the ratio of the true geometry; getOverlapRatio measures a rasterized
+    ## approximation of it, which can read slightly high, so the ceiling is not
+    ## applied at the threshold itself.
+    _OVERLAP_CEILING_MARGIN = 0.05
+
+    @classmethod
+    def _duplicatePairs(cls, entries : list, threshold : float):
+        """Yield every pair of differently-named traces on a section that overlap.
+
+        ``entries`` is one tuple per trace,
+        ``(xmin, ymin, xmax, ymax, area, name, index, trace)``, where the bounds
+        and area are in the trace's own untransformed coordinates (the space
+        Trace.getOverlapRatio works in). Yields
+        ``(entry_a, entry_b, ratio, points_match)`` per overlapping pair, ``a``
+        before ``b`` in (name, index) order so the output does not depend on
+        which order the section's contours were walked in.
+
+        Comparing across names means comparing every trace on the section with
+        every other, and a dense autosegmented section carries enough traces
+        that measuring an overlap ratio for each of those pairs is not viable:
+        Trace.getOverlapRatio rasterizes both polygons, which costs about 3 ms a
+        pair. Two filters keep the number of ratios measured proportional to the
+        number of traces rather than to its square:
+
+          1. **An x-sorted sweep.** Entries are sorted by ``xmin``, so once a
+             later entry starts to the right of where the current one ends, no
+             remaining entry can touch it and the inner loop stops. Pairs whose
+             bounding boxes are disjoint are therefore never even enumerated,
+             and Trace.getOverlapRatio would have answered 0 for all of them.
+          2. **A ceiling on the ratio.** The overlap ratio is an
+             intersection-over-union, so it is at most
+             ``min(box_intersection, area_a, area_b) / max(area_a, area_b)``:
+             the shapes cannot share more than the overlap of their bounding
+             boxes, nor more than the smaller of them, and their union is at
+             least the larger of them. Two traces of the same structure have
+             nearly the same area and nearly the same bounding box, which puts
+             that ceiling near 1; two neighboring autosegmented traces whose
+             boxes merely touch put it near 0.
+
+        Point-for-point matches are settled before either filter can reach them,
+        because a trace with no area at all (a straight line, say) is still a
+        duplicate of an identical copy of itself, and both filters reason about
+        areas. That mirrors Trace.overlaps, which also answers on points first.
+
+        **Every bounding-box test here is slack by Trace's point-match
+        tolerance**, and it has to be. Two traces can match point for point
+        within that tolerance while their bounding boxes do not quite touch, so a
+        strict box test throws away pairs that Trace.overlaps calls duplicates.
+
+            Params:
+                entries (list): per-trace tuples, described above
+                threshold (float): the overlap ratio above which two traces
+                    count as duplicates, as in Trace.overlaps
+            Yields:
+                (tuple): (entry_a, entry_b, ratio, points_match)
+        """
+        ## sorted by xmin so the inner loop can stop rather than run to the end
+        entries = sorted(entries, key=lambda e: e[0])
+        ceiling_floor = threshold - cls._OVERLAP_CEILING_MARGIN
+        tol = Trace.POINTS_MATCH_TOLERANCE
+        n = len(entries)
+        for i in range(n):
+            a = entries[i]
+            axmin, aymin, axmax, aymax, aarea, aname, aindex, atrace = a
+            for j in range(i + 1, n):
+                b = entries[j]
+                bxmin, bymin, bxmax, bymax, barea, bname, bindex, btrace = b
+                if bxmin > axmax + tol:
+                    break  # sorted by xmin: nothing further can reach a
+                if aname == bname:
+                    continue  # same-name duplicates are deleteDuplicateTraces'
+                if atrace.closed != btrace.closed:
+                    continue  # as in Trace.overlaps
+                if aymax + tol < bymin or bymax + tol < aymin:
+                    continue  # boxes overlap in x but not in y
+
+                ## first, second: the pair in a stable order for the caller
+                if (aname, aindex) <= (bname, bindex):
+                    first, second = a, b
+                else:
+                    first, second = b, a
+
+                if atrace.pointsMatch(btrace):
+                    yield first, second, 1.0, True
+                    continue
+
+                ## the ceiling (see the docstring). Both areas zero means there
+                ## is nothing to reason about, and getOverlapRatio answers 0 for
+                ## that case rather than dividing by a collapsed bounding box.
+                ## The box overlap is clamped at zero because the tests above are
+                ## slack by the point-match tolerance, so a pair whose boxes miss
+                ## each other by less than that reaches here.
+                larger = aarea if aarea > barea else barea
+                if larger > 0:
+                    box_intersection = max(
+                        0.0,
+                        min(axmax, bxmax) - max(axmin, bxmin)
+                    ) * max(
+                        0.0,
+                        min(aymax, bymax) - max(aymin, bymin)
+                    )
+                    ceiling = min(box_intersection, aarea, barea) / larger
+                    if ceiling <= ceiling_floor:
+                        continue
+
+                ratio = atrace.getOverlapRatio(btrace)
+                if Trace.ratioIsOverlap(ratio, threshold):
+                    yield first, second, ratio, False
+
+    def findDifferentlyNamedDuplicates(self, threshold : float,
+                                       include_locked=False) -> list:
+        """Find traces that duplicate each other under two different names.
+
+        The same-name case is Series.deleteDuplicateTraces, and it stays exactly
+        as it is: that comparison only ever sees traces already grouped under one
+        contour name, so two people tracing one structure under two names produce
+        a duplicate it cannot find. This scans across names instead, comparing
+        every trace on a section with every other one, and reports what it finds.
+
+        Reports only; nothing is modified. Which of the two names is the right
+        one is a judgment about the data rather than something geometry can
+        settle, so this operation does not choose, and the review list it feeds
+        offers no delete. Locked objects are skipped unless ``include_locked``
+        is True, matching findPixelDustTraces and findEmptyTraces.
+
+        Overlap is decided exactly as it is for same-name duplicates, by
+        Trace.overlaps' two tests: an identical point sequence, or an overlap
+        ratio above ``threshold``. See _duplicatePairs for how the comparison is
+        kept affordable across a whole section.
+
+            Params:
+                threshold (float): the overlap ratio above which two traces
+                    count as duplicates
+                include_locked (bool): True to also consider locked objects
+            Returns:
+                (list): one record per pair (see _cleanupRecord), describing the
+                    first trace of the pair, with the second carried alongside
+                    under the "other_" keys, plus the measured "ratio"
+        """
+        candidates = []
+        for snum, section in self.enumerateSections(
+            message="Scanning for duplicates named differently...",
+        ):
+            tform = section.tform
+            entries = []
+            for cname in section.contours:
+                if not include_locked and self.getAttr(cname, "locked"):
+                    continue
+                for index, trace in enumerate(section.contours[cname]):
+                    if not trace.points:
+                        continue  # nothing to compare; findEmptyTraces' business
+                    xmin, ymin, xmax, ymax = trace.getBounds()
+                    ## the untransformed polygon area, in the same coordinates
+                    ## getOverlapRatio rasterizes, for the ceiling in
+                    ## _duplicatePairs. Not the physical area: that is measured
+                    ## through the section transform, below, for the pairs that
+                    ## survive.
+                    entries.append((
+                        xmin, ymin, xmax, ymax, abs(area(trace.points)),
+                        cname, index, trace
+                    ))
+
+            for first, second, ratio, points_match in self._duplicatePairs(
+                entries, threshold
+            ):
+                fname, findex, ftrace = first[5], first[6], first[7]
+                sname, sindex, strace = second[5], second[6], second[7]
+                if points_match:
+                    reason = f"Point-for-point match with '{sname}'"
+                else:
+                    reason = (
+                        f"Overlap {ratio:.4g} with '{sname}' "
+                        f"(above {threshold:.4g})"
+                    )
+                record = self._cleanupRecord(
+                    fname, snum, findex, ftrace, reason=reason,
+                    area=self._traceArea(ftrace, tform),
+                )
+                other = self._cleanupRecord(
+                    sname, snum, sindex, strace, reason=reason,
+                    area=self._traceArea(strace, tform),
+                )
+                record["ratio"] = ratio
+                record["other_name"] = other["name"]
+                record["other_index"] = other["index"]
+                record["other_points"] = other["points"]
+                record["other_location"] = other["location"]
+                record["other_area"] = other["area"]
+                record["other_match"] = other["match"]
+                candidates.append(record)
+
+        return candidates
 
     def editObjectRadius(self, obj_names : list, new_rad : float, series_states=None):
         """Change the radii of all traces of an object.

--- a/PyReconstruct/modules/datatypes/trace.py
+++ b/PyReconstruct/modules/datatypes/trace.py
@@ -96,9 +96,63 @@ class Trace():
             return False
         return True
 
+    ## How far apart, per axis, two corresponding points may sit and still count
+    ## as the same point. Named because a caller that wants to skip a pair of
+    ## traces cheaply has to allow for it: two traces can match point for point
+    ## under this tolerance while their bounding boxes do not touch, so a
+    ## bounding-box test that rules a pair out has to be slack by this much or it
+    ## will rule out pairs that pointsMatch accepts. Real data has such pairs;
+    ## see Series._duplicatePairs.
+    POINTS_MATCH_TOLERANCE = 1e-2
+
+    def pointsMatch(self, other) -> bool:
+        """Check if two traces are the same point sequence, within a tolerance.
+
+        The cheap half of overlaps(): equal point counts and every pair of
+        corresponding points within POINTS_MATCH_TOLERANCE in both axes. Settled
+        without measuring any area, which is what lets overlaps() answer for
+        shapes that have no area to measure (see getOverlapRatio's zero-area
+        note).
+
+            Params:
+                other (Trace): the trace to compare
+            Returns:
+                (bool): whether the two point sequences coincide
+        """
+        if len(self.points) != len(other.points):
+            return False
+        tol = self.POINTS_MATCH_TOLERANCE
+        for (x1, y1), (x2, y2) in zip(self.points, other.points):
+            if abs(x1-x2) > tol or abs(y1-y2) > tol:
+                return False
+        return True
+
+    @staticmethod
+    def ratioIsOverlap(r : float, threshold : float) -> bool:
+        """Apply the overlap threshold to an already-measured overlap ratio.
+
+        Split out of overlaps() so a caller that needs the ratio itself (to
+        report it, say) can measure once and still reach the same verdict
+        overlaps() would. The threshold is exclusive below 1, and a threshold of
+        exactly 1 demands an exact ratio of 1.
+
+            Params:
+                r (float): an overlap ratio, as returned by getOverlapRatio
+                threshold (float): the threshold overlap ratio (exclusive)
+            Returns:
+                (bool): whether that ratio counts as overlapping
+        """
+        ## bool(), not the comparison itself: getOverlapRatio divides two
+        ## numpy sums, so the comparison yields numpy.bool_ and callers that
+        ## assert `is True` would fail on it. overlaps() has always returned a
+        ## plain bool here and tests hold it to that.
+        if threshold < 1:
+            return bool(r > threshold)
+        return bool(threshold == r == 1)
+
     def overlaps(self, other, threshold=0.99):
         """Check if trace points overlap.
-        
+
             Params:
                 other (Trace): the trace to compare
                 threshold (float): the threshold overlap ratio to define overlapping (exclusive)
@@ -107,27 +161,13 @@ class Trace():
         """
         if self.closed != other.closed:
             return False
-        
+
         # compare points directly
-        points_match = True
-        if len(self.points) != len(other.points):
-            points_match = False
-        else:      
-            for (x1, y1), (x2, y2) in zip(self.points, other.points):
-                if abs(x1-x2) > 1e-2 or abs(y1-y2) > 1e-2:
-                    points_match = False
-                    break
-        if points_match:
+        if self.pointsMatch(other):
             return True
-        
+
         # compare amount of overlap
-        r = self.getOverlapRatio(other)
-        if threshold < 1 and r > threshold:
-            return True
-        elif threshold == r == 1:
-            return True
-        else:
-            return False
+        return self.ratioIsOverlap(self.getOverlapRatio(other), threshold)
     
     def setHidden(self, hidden=True):
         """Set whether the trace is hidden.
@@ -524,6 +564,18 @@ class Trace():
         xmin, xmax = min(xmin1, xmin2), max(xmax1, xmax2)
         ymin, ymax = min(ymin1, ymin2), max(ymax1, ymax2)
         initial_area = (xmax-xmin) * (ymax-ymin)
+
+        # The combined bounding box collapses when both traces sit on the same
+        # vertical or the same horizontal line: a single point and a vertical
+        # run through it, two collinear segments, and so on. Traces like this
+        # are real (smooth() already skips sub-three-point "pixel dust") and
+        # there is no box to rasterize into, so no area to compare. Two such
+        # traces cannot overlap by area, and identical ones are already settled
+        # by the point-by-point comparison in overlaps(), which never asks for a
+        # ratio. Answer 0 rather than dividing by zero.
+        if initial_area == 0:
+            return 0
+
         scale_factor = (1e4 / initial_area) ** 0.5
 
         # scale the points

--- a/PyReconstruct/modules/gui/dialog/__init__.py
+++ b/PyReconstruct/modules/gui/dialog/__init__.py
@@ -19,4 +19,8 @@ from .shortcuts import ShortcutsDialog
 from .backup_comment import BackupCommentDialog
 from .table_columns import TableColumnsDialog
 from .import_series import ImportSeriesDialog
-from .malformed_contours import MalformedContoursDialog
+from .malformed_contours import (
+    MalformedContoursDialog,
+    PixelDustDialog,
+    DifferentlyNamedDuplicatesDialog,
+)

--- a/PyReconstruct/modules/gui/dialog/malformed_contours.py
+++ b/PyReconstruct/modules/gui/dialog/malformed_contours.py
@@ -31,6 +31,25 @@ class MalformedContoursDialog(QDialog):
     """
 
     COLUMNS = ["Object", "Section", "Point count", "Location (x, y)", "Reason"]
+    WINDOW_TITLE = "Traces skipped during smoothing"
+    # column the table is sorted by when it opens; subclasses that put a
+    # different column at index 1 override it to keep the sort meaningful
+    DEFAULT_SORT_COLUMN = 1
+
+    def _columnSpecs(self):
+        """Return (record-key, kind) pairs, one per column in COLUMNS.
+
+        kind is one of "str", "int", "float", "loc" and controls how the cell
+        value is stored (numeric kinds sort numerically). Subclasses override
+        this together with COLUMNS to show different fields.
+        """
+        return [
+            ("name", "str"),
+            ("section", "int"),
+            ("points", "int"),
+            ("location", "loc"),
+            ("reason", "str"),
+        ]
 
     def __init__(self, mainwindow: QWidget, records: list, navigate=None,
                  delete=None):
@@ -58,7 +77,7 @@ class MalformedContoursDialog(QDialog):
         self.navigate = navigate
         self.delete = delete
 
-        self.setWindowTitle("Traces skipped during smoothing")
+        self.setWindowTitle(self.WINDOW_TITLE)
         self.resize(660, 420)
 
         self.heading = QLabel(self._headingText(), self)
@@ -73,7 +92,7 @@ class MalformedContoursDialog(QDialog):
         self.table.setSortingEnabled(False)
         self._populate()
         self.table.setSortingEnabled(True)
-        self.table.sortItems(1)  # default sort by section number
+        self.table.sortItems(self.DEFAULT_SORT_COLUMN)
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.table.cellDoubleClicked.connect(self._onDoubleClick)
 
@@ -118,12 +137,19 @@ class MalformedContoursDialog(QDialog):
             self.delete_all_button.setEnabled(bool(self.records))
             self.delete_all_button.clicked.connect(self.deleteAllContours)
 
+        # subclass hook, run before the selection signal is connected so
+        # anything it adds is already there the first time the slot fires
+        self.extra_buttons = []  # (button, needs_a_selected_row)
+        self._addExtraButtons()
+
         # connected after the buttons exist so the slot can safely touch them
         self.table.itemSelectionChanged.connect(self._updateRowActionButtons)
 
         buttonbox = QDialogButtonBox(QDialogButtonBox.Close, self)
         buttonbox.rejected.connect(self.reject)
         buttonbox.addButton(self.goto_button, QDialogButtonBox.ActionRole)
+        for button, _ in self.extra_buttons:
+            buttonbox.addButton(button, QDialogButtonBox.ActionRole)
         buttonbox.addButton(copy_button, QDialogButtonBox.ActionRole)
         buttonbox.addButton(save_button, QDialogButtonBox.ActionRole)
         if self.delete:
@@ -179,27 +205,27 @@ class MalformedContoursDialog(QDialog):
         # resolve it back to the real record via this map; the key travels with
         # the row through re-sorting.
         self._records_by_key = {}
+        specs = self._columnSpecs()
         for row, r in enumerate(self.records):
 
             self._records_by_key[row] = r
 
-            name_item = QTableWidgetItem(str(r["name"]))
-            name_item.setData(Qt.UserRole, row)
-
-            section_item = QTableWidgetItem()
-            section_item.setData(Qt.DisplayRole, int(r["section"]))
-
-            points_item = QTableWidgetItem()
-            points_item.setData(Qt.DisplayRole, int(r["points"]))
-
-            loc = r.get("location")
-            loc_item = QTableWidgetItem(self._format_location(loc))
-
-            reason_item = QTableWidgetItem(str(r["reason"]))
-
-            for col, item in enumerate(
-                (name_item, section_item, points_item, loc_item, reason_item)
-            ):
+            for col, (key, kind) in enumerate(specs):
+                if kind == "int":
+                    item = QTableWidgetItem()
+                    item.setData(Qt.DisplayRole, int(r[key]))
+                elif kind == "float":
+                    # store as a float so the column sorts numerically
+                    item = QTableWidgetItem()
+                    item.setData(Qt.DisplayRole, round(float(r[key]), 8))
+                elif kind == "loc":
+                    item = QTableWidgetItem(self._format_location(r.get(key)))
+                else:  # "str"
+                    item = QTableWidgetItem(str(r[key]))
+                # a stable per-row key on the first column, resolved back to the
+                # real record by _recordAtRow; it travels with the row on sort
+                if col == 0:
+                    item.setData(Qt.UserRole, row)
                 item.setTextAlignment(Qt.AlignCenter)
                 # show the full cell value on hover; columns are stretched to
                 # fit the window, so wider values (e.g. the Reason) truncate
@@ -213,12 +239,23 @@ class MalformedContoursDialog(QDialog):
             return "—"
         return f"({loc[0]}, {loc[1]})"
 
+    def _addExtraButtons(self):
+        """Subclass hook: append (button, needs_selection) to extra_buttons.
+
+        Nothing here by default. A button appended with needs_selection True is
+        disabled while no row is selected, exactly like "Go to trace".
+        """
+        return
+
     def _updateRowActionButtons(self):
         """Enable selection-dependent buttons only while a row is selected."""
         has_selection = self.table.selectionModel().hasSelection()
         self.goto_button.setEnabled(has_selection)
         if self.delete_selected_button is not None:
             self.delete_selected_button.setEnabled(has_selection)
+        for button, needs_selection in self.extra_buttons:
+            if needs_selection:
+                button.setEnabled(has_selection)
 
     def _recordAtRow(self, row):
         """Return the record for the given table row (or None)."""
@@ -334,3 +371,162 @@ class MalformedContoursDialog(QDialog):
             return
         with open(fp, "w", newline="") as f:
             csv.writer(f).writerows(self._rows_for_export())
+
+
+class PixelDustDialog(MalformedContoursDialog):
+    """Review tiny "pixel-dust" traces before removing them.
+
+    A data clean-up review list: every row is a small closed trace at or below
+    the area threshold the user chose. The user inspects the candidates (and can
+    "Go to trace" to confirm), then deselects any legitimate small trace before
+    "Delete selected" / "Delete all". Reuses all of the selection, navigation,
+    deletion (undoable), and export behavior of MalformedContoursDialog; only
+    the columns (an Area column) and the explanatory heading differ.
+    """
+
+    COLUMNS = ["Object", "Section", "Area (um^2)", "Point count",
+               "Location (x, y)", "Reason"]
+    WINDOW_TITLE = "Remove pixel-dust traces"
+
+    def _columnSpecs(self):
+        return [
+            ("name", "str"),
+            ("section", "int"),
+            ("area", "float"),
+            ("points", "int"),
+            ("location", "loc"),
+            ("reason", "str"),
+        ]
+
+    def _headingText(self):
+        """Explain the pixel-dust review and how to act on it."""
+        num_traces = len(self.records)
+        if not num_traces:
+            return (
+                "All listed traces have been deleted.\n\n"
+                "You can close this window."
+            )
+
+        num_objs = len({r["name"] for r in self.records})
+        trace_word = "trace" if num_traces == 1 else "traces"
+        obj_word = "object" if num_objs == 1 else "objects"
+
+        return (
+            f"{num_traces} small (pixel-dust) {trace_word} across "
+            f"{num_objs} {obj_word} at or below the area threshold.\n\n"
+            "These are typically stray specks left by segmentation. Review the "
+            "candidates below, select a row and click “Go to trace” to inspect "
+            "one, and deselect any legitimate trace you want to keep. Then use "
+            "“Delete selected” or “Delete all” to remove them (can be undone)."
+            "\n\nNothing is removed until you choose to delete."
+        )
+
+
+class DifferentlyNamedDuplicatesDialog(MalformedContoursDialog):
+    """Report traces that duplicate each other under two different names.
+
+    Each row is a pair: one shape traced twice, once under each of two object
+    names, which is what happens when two people trace the same structure. Both
+    names are shown, along with the measured overlap and each trace's area, so
+    the pair can be judged rather than guessed at. "Go to trace" frames the first
+    of the two and "Go to other trace" frames the second, so the same field view
+    can be compared against both.
+
+    This list reports and does not delete. Two traces sharing one name are
+    unambiguous and Series.deleteDuplicateTraces collapses them, but when the
+    names differ, which name is the right one is a question about the data: the
+    two objects may have different hosts, groups, or curation status, and the
+    answer can be to rename or to merge rather than to delete. So the pairs are
+    reported, and what to do about each one is left to the person reading them.
+    """
+
+    COLUMNS = ["Object", "Duplicate of", "Section", "Overlap", "Area (um^2)",
+               "Other area (um^2)", "Point count", "Location (x, y)", "Reason"]
+    WINDOW_TITLE = "Duplicates named differently"
+    DEFAULT_SORT_COLUMN = 2  # "Section"
+
+    def __init__(self, mainwindow: QWidget, records: list, navigate=None):
+        """Create the pairs list. Takes no delete callback, on purpose.
+
+        Report-only is a property of this dialog rather than a choice each caller
+        makes, so there is no ``delete`` parameter to pass one through: adding
+        deletion here has to be a deliberate change to this class.
+
+            Params:
+                mainwindow (QWidget): the parent window
+                records (list): pair records from
+                    Series.findDifferentlyNamedDuplicates
+                navigate (callable): optional navigate(section_num, obj_name,
+                    index) callback, used by both "Go to" buttons
+        """
+        super().__init__(mainwindow, records, navigate=navigate, delete=None)
+
+    def _columnSpecs(self):
+        return [
+            ("name", "str"),
+            ("other_name", "str"),
+            ("section", "int"),
+            ("ratio", "float"),
+            ("area", "float"),
+            ("other_area", "float"),
+            ("points", "int"),
+            ("location", "loc"),
+            ("reason", "str"),
+        ]
+
+    def _addExtraButtons(self):
+        """Add "Go to other trace", which frames the pair's second trace."""
+        self.goto_other_button = QPushButton("Go to other trace", self)
+        self.goto_other_button.setToolTip(
+            "Focus the field on the other trace of the selected pair"
+        )
+        self.goto_other_button.setEnabled(False)
+        self.goto_other_button.clicked.connect(self.goToSelectedOtherContour)
+        self.extra_buttons.append((self.goto_other_button, True))
+
+    def goToSelectedOtherContour(self):
+        """Focus the field on the second trace of the selected pair."""
+        if not self.navigate:
+            return
+        rows = self.table.selectionModel().selectedRows()
+        if not rows:
+            return
+        record = self._recordAtRow(rows[0].row())
+        if record is None:
+            return
+        self.navigate(
+            record["section"], record["other_name"], record["other_index"]
+        )
+
+    def _headingText(self):
+        """Explain what a row is and why nothing is deleted from here."""
+        num_pairs = len(self.records)
+        if not num_pairs:
+            return (
+                "No pairs left to report.\n\n"
+                "You can close this window."
+            )
+
+        names = {r["name"] for r in self.records} | {
+            r["other_name"] for r in self.records
+        }
+        pair_word = "pair" if num_pairs == 1 else "pairs"
+
+        return (
+            f"{num_pairs} {pair_word} of overlapping traces across "
+            f"{len(names)} objects, each pair traced under two different "
+            "names.\n\n"
+            "Two traces of one object that sit on top of each other are "
+            "duplicates without any doubt, and "
+            "“Remove duplicate traces...” collapses those. When the names "
+            "differ the geometry says the same thing, but which name is the "
+            "right one does not follow from it: the two objects can carry "
+            "different hosts, groups or curation, and the answer may be to "
+            "rename or to merge rather than to delete one.\n\n"
+            "So this list reports. Select a row and use “Go to trace” and "
+            "“Go to other trace” to see both traces of a pair in the field, "
+            "then decide. The Overlap column is the measured overlap ratio "
+            "(1 means the two traces have the same points), and both areas "
+            "are physical (um^2) on that trace's own section.\n\n"
+            "Nothing in the series has been changed."
+        )

--- a/PyReconstruct/modules/gui/main/main_imports.py
+++ b/PyReconstruct/modules/gui/main/main_imports.py
@@ -56,6 +56,8 @@ from PyReconstruct.modules.gui.dialog import (
     ShortcutsDialog,
     BackupCommentDialog,
     ImportSeriesDialog,
+    PixelDustDialog,
+    DifferentlyNamedDuplicatesDialog,
 )
 
 from PyReconstruct.modules.gui.popup import (

--- a/PyReconstruct/modules/gui/main/main_window.py
+++ b/PyReconstruct/modules/gui/main/main_window.py
@@ -2384,6 +2384,123 @@ class MainWindow(QMainWindow):
         self.field.reload()
         self.seriesModified(True)
 
+    def findDifferentlyNamedDuplicates(self):
+        """Report traces that duplicate each other under two different names.
+
+        The sibling of "Remove duplicate traces...", for the case that one
+        cannot see: two people tracing the same structure give it two names, so
+        the two traces never end up in the same contour and the same-name
+        comparison never puts them side by side.
+
+        This reports and does not delete. Which of the two names survives is a
+        question about the data rather than about geometry, so the review list
+        opens without a delete callback and nothing in the series is touched.
+        """
+        self.saveAllData()
+
+        # the same two controls as "Remove duplicate traces...", so the pair of
+        # operations reads the same way
+        structure = [
+            ["Overlap threshold:", ("float", 0.95, (0, 1))],
+            [("check", ("check locked traces", False))]
+        ]
+        response, confirmed = QuickDialog.get(
+            self, structure, "Find duplicates named differently"
+        )
+        if not confirmed:
+            return
+        threshold = response[0]
+        include_locked = response[1][0][1]
+
+        pairs = self.series.findDifferentlyNamedDuplicates(
+            threshold, include_locked
+        )
+        if not pairs:
+            notify(
+                "No differently-named duplicate traces found at that overlap "
+                "threshold."
+            )
+            return
+
+        # review list only: no delete callback, so the dialog shows no Delete
+        # buttons and this operation cannot change the series
+        self.differently_named_duplicates_dialog = (
+            DifferentlyNamedDuplicatesDialog(
+                self,
+                pairs,
+                navigate=self.field.focusMalformedContour,
+            )
+        )
+        self.differently_named_duplicates_dialog.show()
+
+    def removePixelDustTraces(self):
+        """Find tiny "pixel-dust" traces and remove them through a review list.
+
+        Scans the series for small closed traces at or below a user-chosen area
+        threshold (um^2), then opens a reviewable list: nothing is removed until
+        the user inspects the candidates, deselects any to keep, and deletes.
+        Deletion is a single undoable operation (see deleteMalformedContours).
+        """
+        self.saveAllData()
+
+        structure = [
+            ["Maximum trace area (um^2):", ("float", 0.01)],
+        ]
+        response, confirmed = QuickDialog.get(
+            self, structure, "Remove pixel-dust traces"
+        )
+        if not confirmed:
+            return
+        threshold = response[0]
+        if threshold is None or threshold <= 0:
+            notify("Please enter an area threshold greater than zero.")
+            return
+
+        # locked objects are always left alone: the review-list delete path
+        # (deleteMalformedContours) refuses locked objects, so surfacing them
+        # here would be a dead end. Empty-trace removal skips locked the same way.
+        candidates = self.series.findPixelDustTraces(threshold)
+        if not candidates:
+            notify("No pixel-dust traces found at or below that area.")
+            return
+
+        # reviewable list: the user confirms/deselects before anything is deleted
+        self.pixel_dust_dialog = PixelDustDialog(
+            self,
+            candidates,
+            navigate=self.field.focusMalformedContour,
+            delete=self.field.deleteMalformedContours,
+        )
+        self.pixel_dust_dialog.show()
+
+    def removeEmptyTraces(self):
+        """Find and remove empty / degenerate traces (no meaningful geometry).
+
+        These are unambiguous (no points, zero-area closed traces, or zero-length
+        open traces), so they are removed after a single count-stating
+        confirmation rather than a review list. Locked objects are left alone.
+        Removal is one undoable operation.
+        """
+        self.saveAllData()
+
+        candidates = self.series.findEmptyTraces(include_locked=False)
+        if not candidates:
+            notify("No empty traces found.")
+            return
+
+        count = len(candidates)
+        noun = "empty trace" if count == 1 else "empty traces"
+        if not notifyConfirm(
+            f"Remove {count} {noun} from the series?\n\n"
+            "This can be undone (Ctrl+Z).",
+            yn=True,
+        ):
+            return
+
+        deleted = self.field.deleteMalformedContours(candidates)
+        if deleted:
+            notify(f"Removed {len(deleted)} {noun}.")
+
     def addTo3D(self, names, ztraces=False):
         """Generate the 3D view for a list of objects.
         

--- a/PyReconstruct/modules/gui/main/menubar.py
+++ b/PyReconstruct/modules/gui/main/menubar.py
@@ -197,7 +197,17 @@ def return_series_menu(self):
             },
             None,
             ("findobjectfirst_act", "Find first object contour...", self.series, self.findObjectFirst),
-            ("removeduplicates_act", "Remove duplicate traces", "", self.deleteDuplicateTraces),
+            {
+                "attr_name": "cleanupmenu",
+                "text": "Clean up",
+                "opts":
+                [
+                    ("removeduplicates_act", "Remove duplicate traces...", "", self.deleteDuplicateTraces),
+                    ("finddiffnamedduplicates_act", "Find duplicates named differently...", "", self.findDifferentlyNamedDuplicates),
+                    ("removepixeldust_act", "Remove pixel-dust traces...", "", self.removePixelDustTraces),
+                    ("removeempty_act", "Remove empty traces...", "", self.removeEmptyTraces),
+                ]
+            },
             None,
             ("updatecuration_act", "Update curation from history", "", self.updateCurationFromHistory),
             None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,24 @@ dependencies = [
     "packaging",
 ]
 
+# Test-only, not installed for end users. Qt is already a runtime dependency,
+# so the widget tests need nothing beyond pytest itself.
+[project.optional-dependencies]
+test = [
+    "pytest>=8",
+]
+
 [project.urls]
 Homepage = "https://github.com/SynapseWeb/PyReconstruct"
 
 [project.scripts]
 PyReconstruct = "PyReconstruct.cli:main"
+
+# testpaths keeps collection inside tests/. Without it pytest also picks up
+# packaging/smoke_test.py, which is a launcher check for a frozen build rather
+# than a unit test and crashes when imported into a test session.
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.setuptools.packages.find]
 include = ["PyReconstruct*"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+"""Shared setup for the test suite.
+
+Two things have to happen before any test module imports the application:
+
+* Qt has to run without a display, so the widget tests work over ssh and in CI.
+
+* QSettings has to be redirected. The application reads and writes real user
+  settings through ``QSettings("KHLab", "PyReconstruct")``, and
+  ``Series.getOption`` writes a default back whenever a key is missing, so a
+  test that touched an option would edit the settings of whoever ran it. Every
+  call site constructs ``QSettings(organization, application)``, which resolves
+  to the native backend: a plist through ``cfprefsd`` on macOS, the registry on
+  Windows. Neither ``setPath`` nor ``setDefaultFormat`` moves that (``setPath``
+  documents no effect on the native backends, and a native default is what the
+  two-argument constructor resolves to regardless), and redirecting ``$HOME``
+  does not either, because ``cfprefsd`` resolves the real user's domain. What
+  does work is binding the name the application imports to a subclass that
+  hands every instance an explicit INI file under a temporary directory.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+import PySide6.QtCore
+
+_RealQSettings = PySide6.QtCore.QSettings
+_SETTINGS_DIR = tempfile.mkdtemp(prefix="pyrecon-test-settings-")
+
+
+class _TempQSettings(_RealQSettings):
+    """QSettings backed by a throwaway INI file, keyed by organization/app."""
+
+    def __init__(self, *args, **kwargs):
+        organization = args[0] if args else "test"
+        application = args[1] if len(args) > 1 else "test"
+        super().__init__(
+            os.path.join(_SETTINGS_DIR, f"{organization}.{application}.ini"),
+            _RealQSettings.Format.IniFormat,
+        )
+
+
+PySide6.QtCore.QSettings = _TempQSettings
+
+# for the test that guards the redirect
+SETTINGS_DIR = _SETTINGS_DIR
+REAL_QSETTINGS = _RealQSettings
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """The one QApplication the widget tests share."""
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication(["pytest"])
+    yield app
+
+
+@pytest.fixture
+def real_series(qapp, tmp_path):
+    """A real series opened from the checker fixture, on a copy.
+
+    Nothing is stubbed: the palette, the sections and the object data are the
+    ones the application would load.
+    """
+    import shutil
+
+    from PyReconstruct.modules.datatypes.series import Series
+    from PyReconstruct.modules.datatypes.series_data import SeriesData
+
+    src = os.path.join(
+        os.path.dirname(__file__), "..", "PyReconstruct", "assets",
+        "checker", "files", "shapes1.jser",
+    )
+    assert os.path.exists(src), f"missing test fixture: {src}"
+
+    fp = str(tmp_path / "shapes1.jser")
+    shutil.copyfile(src, fp)
+
+    series = Series.openJser(fp)
+    data = SeriesData(series)
+    data.refresh()
+    series.data = data
+
+    yield series
+
+    series.close()

--- a/tests/test_cleanup_dialogs.py
+++ b/tests/test_cleanup_dialogs.py
@@ -1,0 +1,219 @@
+"""The two clean-up review lists, driven as real widgets.
+
+``MalformedContoursDialog`` grew a column spec, a default sort column and a
+subclass button hook so the two clean-up lists could reuse its selection,
+navigation, deletion and export behavior instead of restating it.
+
+The property worth pinning is that ``DifferentlyNamedDuplicatesDialog`` reports
+and does not delete, and that this is a property of the class rather than a
+keyword each call site chooses: it takes no ``delete`` parameter at all, so
+adding deletion has to be a deliberate change here.
+"""
+
+import inspect
+
+import pytest
+
+from PyReconstruct.modules.gui.dialog import (
+    MalformedContoursDialog,
+    PixelDustDialog,
+    DifferentlyNamedDuplicatesDialog,
+)
+
+
+@pytest.fixture
+def parent(qapp):
+    from PySide6.QtWidgets import QWidget
+
+    widget = QWidget()
+    yield widget
+    widget.deleteLater()
+
+
+def _dust_record(name="dust", snum=3, area=0.004):
+    return {
+        "name": name,
+        "section": snum,
+        "index": 0,
+        "points": 4,
+        "location": (20.0, 20.0),
+        "reason": f"Area {area} um^2",
+        "area": area,
+        "match": {"color": (255, 0, 0), "points": [(20.0, 20.0)]},
+    }
+
+
+def _pair_record(name="dendrite", other="d01", snum=3, ratio=0.98):
+    return {
+        "name": name,
+        "section": snum,
+        "index": 0,
+        "points": 4,
+        "location": (20.0, 20.0),
+        "reason": f"Overlap {ratio} with '{other}'",
+        "area": 1.5,
+        "ratio": ratio,
+        "other_name": other,
+        "other_index": 1,
+        "other_points": 4,
+        "other_location": (20.1, 20.1),
+        "other_area": 1.4,
+        "other_match": {"color": (0, 255, 0), "points": [(20.1, 20.1)]},
+        "match": {"color": (255, 0, 0), "points": [(20.0, 20.0)]},
+    }
+
+
+# --------------------------------------------------------------------------
+# the pairs list reports and does not delete
+# --------------------------------------------------------------------------
+
+def test_report_only_is_a_property_of_the_class():
+    """No delete parameter, so no call site can turn deletion on."""
+    params = inspect.signature(DifferentlyNamedDuplicatesDialog.__init__).parameters
+
+    assert "delete" not in params
+
+
+def test_the_pairs_list_shows_no_delete_buttons(parent):
+    dialog = DifferentlyNamedDuplicatesDialog(parent, [_pair_record()])
+
+    assert dialog.delete is None
+    assert dialog.delete_selected_button is None
+    assert dialog.delete_all_button is None
+
+
+def test_the_heading_says_nothing_was_changed(parent):
+    dialog = DifferentlyNamedDuplicatesDialog(parent, [_pair_record()])
+
+    assert "Nothing in the series has been changed" in dialog.heading.text()
+
+
+def test_the_row_names_both_objects_and_shows_the_overlap(parent):
+    dialog = DifferentlyNamedDuplicatesDialog(
+        parent, [_pair_record(name="dendrite", other="d01", ratio=0.98)]
+    )
+
+    assert dialog.COLUMNS[:4] == ["Object", "Duplicate of", "Section", "Overlap"]
+    texts = [
+        dialog.table.item(0, col).text()
+        for col in range(dialog.table.columnCount())
+    ]
+    assert "dendrite" in texts
+    assert "d01" in texts
+    assert any("0.98" in t for t in texts)
+
+
+def test_both_traces_of_a_pair_are_reachable(parent):
+    """Two navigation buttons, each framing its own side of the pair."""
+    visited = []
+    dialog = DifferentlyNamedDuplicatesDialog(
+        parent,
+        [_pair_record(name="dendrite", other="d01")],
+        navigate=lambda snum, name, index: visited.append((snum, name, index)),
+    )
+    dialog.table.selectRow(0)
+
+    dialog.goToSelectedContour()
+    dialog.goToSelectedOtherContour()
+
+    assert visited == [(3, "dendrite", 0), (3, "d01", 1)]
+
+
+def test_the_go_to_buttons_are_off_until_a_row_is_selected(parent):
+    dialog = DifferentlyNamedDuplicatesDialog(
+        parent, [_pair_record()], navigate=lambda *a: None
+    )
+
+    assert dialog.goto_button.isEnabled() is False
+    assert dialog.goto_other_button.isEnabled() is False
+
+    dialog.table.selectRow(0)
+
+    assert dialog.goto_button.isEnabled() is True
+    assert dialog.goto_other_button.isEnabled() is True
+
+
+def test_the_pairs_table_opens_sorted_by_section(parent):
+    """Section moved to column 2 here, so the inherited sort index would be wrong.
+
+    The names run opposite to the section numbers on purpose: sorting by either
+    of the two name columns would put the rows in the reverse order, so a
+    hardcoded sort column cannot pass this by coincidence.
+    """
+    records = [
+        _pair_record(name="a", other="a2", snum=9),
+        _pair_record(name="c", other="c2", snum=1),
+        _pair_record(name="b", other="b2", snum=5),
+    ]
+    dialog = DifferentlyNamedDuplicatesDialog(parent, records)
+
+    section_col = dialog.COLUMNS.index("Section")
+    assert section_col == dialog.DEFAULT_SORT_COLUMN
+    shown = [
+        int(dialog.table.item(row, section_col).text())
+        for row in range(dialog.table.rowCount())
+    ]
+    assert shown == [1, 5, 9]
+
+
+# --------------------------------------------------------------------------
+# the pixel-dust list still deletes, and the base class is unchanged
+# --------------------------------------------------------------------------
+
+def test_the_pixel_dust_list_deletes_what_was_reviewed(parent, monkeypatch):
+    # the confirmation prompt falls back to reading stdin without a GUI
+    monkeypatch.setattr(
+        "PyReconstruct.modules.gui.dialog.malformed_contours.notifyConfirm",
+        lambda *args, **kwargs: True,
+    )
+    handed = []
+    records = [_dust_record("dust"), _dust_record("other")]
+    dialog = PixelDustDialog(
+        parent, records, delete=lambda recs: (handed.extend(recs), recs)[1]
+    )
+
+    assert dialog.delete_all_button is not None
+    dialog._deleteRecords([records[0]])
+
+    assert [r["name"] for r in handed] == ["dust"]
+
+
+def test_a_declined_confirmation_deletes_nothing(parent, monkeypatch):
+    monkeypatch.setattr(
+        "PyReconstruct.modules.gui.dialog.malformed_contours.notifyConfirm",
+        lambda *args, **kwargs: False,
+    )
+    handed = []
+    records = [_dust_record("dust")]
+    dialog = PixelDustDialog(
+        parent, records, delete=lambda recs: (handed.extend(recs), recs)[1]
+    )
+
+    dialog._deleteRecords(records)
+
+    assert handed == []
+
+
+def test_the_pixel_dust_list_shows_an_area_column(parent):
+    dialog = PixelDustDialog(parent, [_dust_record(area=0.004)])
+
+    assert "Area (um^2)" in dialog.COLUMNS
+    col = dialog.COLUMNS.index("Area (um^2)")
+    assert "0.004" in dialog.table.item(0, col).text()
+
+
+def test_neither_list_grows_a_button_the_base_class_did_not_ask_for(parent):
+    """The hook is opt-in, so the smoothing report is unaffected by it."""
+    base = MalformedContoursDialog(parent, [_dust_record()])
+    dust = PixelDustDialog(parent, [_dust_record()])
+
+    assert base.extra_buttons == []
+    assert dust.extra_buttons == []
+
+
+def test_the_base_class_still_sorts_by_section_and_titles_itself(parent):
+    base = MalformedContoursDialog(parent, [_dust_record()])
+
+    assert base.DEFAULT_SORT_COLUMN == 1
+    assert base.COLUMNS[1] == "Section"
+    assert base.windowTitle() == "Traces skipped during smoothing"

--- a/tests/test_cross_name_duplicates.py
+++ b/tests/test_cross_name_duplicates.py
@@ -1,0 +1,387 @@
+"""``Series.findDifferentlyNamedDuplicates``: one shape traced under two names.
+
+``Series.deleteDuplicateTraces`` draws both traces of a candidate pair out of a
+single ``section.contours[cname]``, and contours are keyed by trace name, so two
+people tracing the same structure under two names produce a duplicate it never
+compares. Nothing in the comparison itself reads a name: ``Trace.overlaps`` is
+purely geometric. This is therefore a new scan across names rather than a change
+to the overlap test, and the tests below hold both halves of that: the new scan
+finds cross-name pairs, and the existing same-name operation still behaves
+exactly as it did.
+
+The scan reports and never modifies. Which of two names is the right one is a
+question about the data rather than about geometry, so the operation does not
+choose.
+
+``_duplicatePairs`` is where the cost lives, since comparing across names means
+comparing every trace on a section against every other. Two filters keep the
+number of measured overlap ratios proportional to the trace count rather than to
+its square, and ``test_the_filtered_scan_agrees_with_brute_force`` is the test
+that matters most here: the filters are only allowed to be faster, never to
+change an answer.
+"""
+
+import pytest
+
+from PyReconstruct.modules.datatypes.trace import Trace
+
+
+def _trace(points, closed=True, name="t"):
+    t = Trace(name, (255, 0, 0), closed=closed)
+    t.points = list(points)
+    return t
+
+
+def _template(section):
+    for cname in section.contours:
+        for trace in section.contours[cname]:
+            if trace.closed and len(trace.points) >= 3:
+                return trace
+    pytest.skip("no closed trace in the fixture section")
+
+
+def _add(series, snum, name, points, closed=True):
+    section = series.loadSection(snum)
+    template = _template(section)
+    trace = Trace(name, template.color, closed=closed)
+    trace.points = list(points)
+    section.addTrace(trace, log_event=False)
+    section.save()
+
+
+def _square(cx, cy, half):
+    return [
+        (cx - half, cy - half),
+        (cx + half, cy - half),
+        (cx + half, cy + half),
+        (cx - half, cy + half),
+    ]
+
+
+def _first_section(series):
+    return sorted(series.sections.keys())[0]
+
+
+def _pairs(records):
+    """The reported pairs as name sets, so row order never matters."""
+    return {frozenset((r["name"], r["other_name"])) for r in records}
+
+
+# --------------------------------------------------------------------------
+# what the scan finds
+# --------------------------------------------------------------------------
+
+def test_one_shape_under_two_names_is_found(real_series):
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "dendrite", shape)
+    _add(real_series, snum, "d01", shape)
+
+    found = real_series.findDifferentlyNamedDuplicates(0.95)
+
+    assert frozenset(("dendrite", "d01")) in _pairs(found)
+
+
+def test_a_point_for_point_match_is_reported_as_such(real_series):
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "dendrite", shape)
+    _add(real_series, snum, "d01", shape)
+
+    record = real_series.findDifferentlyNamedDuplicates(0.95)[0]
+
+    assert record["ratio"] == 1.0
+    assert "Point-for-point match" in record["reason"]
+
+
+def test_nearly_identical_shapes_are_found_by_their_overlap_ratio(real_series):
+    """Not the same points, so the ratio has to do the work.
+
+    The offset has to clear ``POINTS_MATCH_TOLERANCE``, or ``pointsMatch``
+    settles the pair first and the ratio is never measured.
+    """
+    snum = _first_section(real_series)
+    offset = Trace.POINTS_MATCH_TOLERANCE * 2
+    _add(real_series, snum, "dendrite", _square(20, 20, 1.0))
+    _add(real_series, snum, "d01", _square(20 + offset, 20 + offset, 1.0))
+
+    found = real_series.findDifferentlyNamedDuplicates(0.95)
+    record = [
+        r for r in found
+        if {r["name"], r["other_name"]} == {"dendrite", "d01"}
+    ]
+
+    assert len(record) == 1
+    assert record[0]["ratio"] < 1.0
+    assert "Overlap" in record[0]["reason"]
+
+
+def test_different_shapes_are_not_reported(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "one", _square(20, 20, 1.0))
+    _add(real_series, snum, "two", _square(40, 40, 1.0))
+
+    found = _pairs(real_series.findDifferentlyNamedDuplicates(0.95))
+
+    assert frozenset(("one", "two")) not in found
+
+
+def test_merely_touching_neighbors_are_not_reported(real_series):
+    """Two autosegmented neighbors share a boundary without being duplicates."""
+    snum = _first_section(real_series)
+    _add(real_series, snum, "left", _square(20, 20, 1.0))
+    _add(real_series, snum, "right", _square(21.9, 20, 1.0))
+
+    found = _pairs(real_series.findDifferentlyNamedDuplicates(0.95))
+
+    assert frozenset(("left", "right")) not in found
+
+
+def test_the_threshold_is_honored(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "a", _square(20, 20, 1.0))
+    _add(real_series, snum, "b", _square(20.5, 20, 1.0))
+
+    pair = frozenset(("a", "b"))
+    strict = _pairs(real_series.findDifferentlyNamedDuplicates(0.95))
+    loose = _pairs(real_series.findDifferentlyNamedDuplicates(0.1))
+
+    assert pair not in strict
+    assert pair in loose
+
+
+def test_open_and_closed_traces_never_pair(real_series):
+    """As in Trace.overlaps, which refuses the comparison outright."""
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "closed_one", shape, closed=True)
+    _add(real_series, snum, "open_one", shape, closed=False)
+
+    found = _pairs(real_series.findDifferentlyNamedDuplicates(0.1))
+
+    assert frozenset(("closed_one", "open_one")) not in found
+
+
+def test_same_name_duplicates_are_not_this_operations_business(real_series):
+    """They are unambiguous, and deleteDuplicateTraces already collapses them."""
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "twice", shape)
+    _add(real_series, snum, "twice", shape)
+
+    found = real_series.findDifferentlyNamedDuplicates(0.95)
+
+    assert all(r["name"] != r["other_name"] for r in found)
+    assert frozenset(("twice",)) not in _pairs(found)
+
+
+def test_the_same_name_operation_still_leaves_cross_name_pairs_alone(real_series):
+    """The existing path is untouched, which is what makes the new one needed."""
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "dendrite", shape)
+    _add(real_series, snum, "d01", shape)
+
+    real_series.deleteDuplicateTraces(0.95, include_locked=True)
+
+    contours = real_series.loadSection(snum).contours
+    assert len(contours["dendrite"]) == 1
+    assert len(contours["d01"]) == 1
+
+
+def test_locked_objects_are_left_out(real_series):
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "dendrite", shape)
+    _add(real_series, snum, "d01", shape)
+    real_series.setAttr("d01", "locked", True)
+
+    pair = frozenset(("dendrite", "d01"))
+    assert pair not in _pairs(real_series.findDifferentlyNamedDuplicates(0.95))
+    assert pair in _pairs(
+        real_series.findDifferentlyNamedDuplicates(0.95, include_locked=True)
+    )
+
+
+def test_zero_area_traces_are_settled_on_points_and_do_not_raise(real_series):
+    """Both filters reason about area, so a shape with none must bypass them."""
+    snum = _first_section(real_series)
+    line = [(60, 60), (61, 60), (62, 60)]
+    _add(real_series, snum, "flat_a", line)
+    _add(real_series, snum, "flat_b", line)
+
+    found = _pairs(real_series.findDifferentlyNamedDuplicates(0.95))
+
+    assert frozenset(("flat_a", "flat_b")) in found
+
+
+# --------------------------------------------------------------------------
+# the record, and that nothing is modified
+# --------------------------------------------------------------------------
+
+def test_the_record_describes_both_traces_of_the_pair(real_series):
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "dendrite", shape)
+    _add(real_series, snum, "d01", shape)
+
+    record = real_series.findDifferentlyNamedDuplicates(0.95)[0]
+
+    for key in (
+        "name", "other_name", "section", "ratio", "area", "other_area",
+        "points", "location", "other_location", "other_index", "other_match",
+    ):
+        assert key in record, f"record is missing {key}"
+    assert record["area"] > 0
+    assert record["other_area"] > 0
+
+
+@pytest.mark.parametrize("threshold", [0, 0.1, 0.5, 0.95, 1])
+def test_the_scan_modifies_nothing_at_any_threshold(real_series, threshold):
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "dendrite", shape)
+    _add(real_series, snum, "d01", shape)
+
+    def snapshot():
+        out = {}
+        for n in sorted(real_series.sections.keys()):
+            section = real_series.loadSection(n)
+            out[n] = {
+                c: [list(t.points) for t in section.contours[c]]
+                for c in section.contours
+            }
+        return out
+
+    before = snapshot()
+    real_series.findDifferentlyNamedDuplicates(threshold)
+
+    assert snapshot() == before
+
+
+def test_the_pair_order_does_not_depend_on_contour_walk_order(real_series):
+    """A stable (name, index) order, so the report is reproducible."""
+    snum = _first_section(real_series)
+    shape = _square(20, 20, 1.0)
+    _add(real_series, snum, "zzz", shape)
+    _add(real_series, snum, "aaa", shape)
+
+    record = [
+        r for r in real_series.findDifferentlyNamedDuplicates(0.95)
+        if {r["name"], r["other_name"]} == {"aaa", "zzz"}
+    ][0]
+
+    assert record["name"] == "aaa"
+    assert record["other_name"] == "zzz"
+
+
+# --------------------------------------------------------------------------
+# the filters are only allowed to be faster
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("threshold", [0.1, 0.5, 0.8, 0.95, 1])
+def test_the_filtered_scan_agrees_with_brute_force(threshold):
+    """Every pair the filters skip is a pair Trace.overlaps would have refused.
+
+    Brute force is every cross-name pair straight into ``Trace.overlaps``, which
+    is what a literal rewrite of the same-name loop gives. The sweep and the
+    ratio ceiling must reach the same set.
+    """
+    from PyReconstruct.modules.datatypes.series import Series
+    from PyReconstruct.modules.calc import area
+
+    traces = []
+    # a crowd with real overlaps, near misses, and plenty of disjoint pairs
+    for i in range(12):
+        cx = i * 1.7
+        traces.append((f"obj{i}", _square(cx, 0, 1.0)))
+        traces.append((f"copy{i}", _square(cx, 0, 1.0)))          # duplicate
+        traces.append((f"near{i}", _square(cx + 0.3, 0, 1.0)))    # partial
+        traces.append((f"far{i}", _square(cx, 40 + i, 1.0)))      # disjoint
+
+    entries = []
+    for index, (name, points) in enumerate(traces):
+        t = _trace(points, name=name)
+        xmin, ymin, xmax, ymax = t.getBounds()
+        entries.append((xmin, ymin, xmax, ymax, abs(area(points)), name, 0, t))
+
+    filtered = {
+        frozenset((a[5], b[5]))
+        for a, b, _r, _pm in Series._duplicatePairs(entries, threshold)
+    }
+
+    brute = set()
+    for i in range(len(entries)):
+        for j in range(i + 1, len(entries)):
+            a, b = entries[i], entries[j]
+            if a[5] == b[5]:
+                continue
+            if a[7].overlaps(b[7], threshold=threshold):
+                brute.add(frozenset((a[5], b[5])))
+
+    assert filtered == brute
+
+
+def test_a_pair_matching_within_tolerance_with_disjoint_boxes_is_found():
+    """The bounding-box tests have to be slack by the point-match tolerance.
+
+    ``Trace.pointsMatch`` calls two points the same within
+    ``POINTS_MATCH_TOLERANCE`` per axis, so two traces can match point for point
+    while their bounding boxes do not touch. A strict box test drops exactly the
+    pairs the comparison would have called duplicates, and real data has them.
+    """
+    from PyReconstruct.modules.datatypes.series import Series
+    from PyReconstruct.modules.calc import area
+
+    offset = Trace.POINTS_MATCH_TOLERANCE * 0.6
+    a_points = [(0, 0), (1, 0)]
+    b_points = [(0, offset), (1, offset)]
+
+    entries = []
+    for name, points in (("a", a_points), ("b", b_points)):
+        t = _trace(points, closed=False, name=name)
+        xmin, ymin, xmax, ymax = t.getBounds()
+        entries.append((xmin, ymin, xmax, ymax, abs(area(points)), name, 0, t))
+
+    pairs = list(Series._duplicatePairs(entries, 0.95))
+
+    assert len(pairs) == 1
+    assert pairs[0][3] is True  # settled on points
+    assert _trace(a_points, closed=False).overlaps(
+        _trace(b_points, closed=False), threshold=0.95
+    ) is True
+
+
+# --------------------------------------------------------------------------
+# the two halves extracted out of overlaps()
+# --------------------------------------------------------------------------
+
+def test_points_match_carries_the_tolerance():
+    tol = Trace.POINTS_MATCH_TOLERANCE
+    a = _trace([(0, 0), (1, 0), (1, 1)])
+
+    assert a.pointsMatch(_trace([(0, tol * 0.5), (1, 0), (1, 1)])) is True
+    assert a.pointsMatch(_trace([(0, tol * 2), (1, 0), (1, 1)])) is False
+    assert a.pointsMatch(_trace([(0, 0), (1, 0)])) is False
+
+
+@pytest.mark.parametrize("ratio, threshold, expected", [
+    (0.96, 0.95, True),
+    (0.95, 0.95, False),   # exclusive
+    (1.0, 1, True),
+    (0.999, 1, False),     # a threshold of 1 demands exactly 1
+])
+def test_ratio_is_overlap_matches_the_threshold_semantics(
+    ratio, threshold, expected
+):
+    assert Trace.ratioIsOverlap(ratio, threshold) is expected
+
+
+def test_overlaps_still_answers_with_a_plain_bool():
+    """getOverlapRatio divides two numpy sums, so the verdict must be coerced."""
+    a = _trace(_square(0, 0, 1.0))
+    b = _trace(_square(0.1, 0, 1.0))
+
+    for threshold in (0.1, 0.95, 1):
+        verdict = a.overlaps(b, threshold=threshold)
+        assert type(verdict) is bool, f"{threshold} gave {type(verdict)}"

--- a/tests/test_data_cleanup.py
+++ b/tests/test_data_cleanup.py
@@ -1,0 +1,401 @@
+"""The Series ▸ Clean up operations: pixel dust, empty traces, duplicates.
+
+Three scans and one guard, all against the real ``shapes1.jser`` fixture with
+synthetic traces layered on top of it:
+
+* ``Series.findPixelDustTraces`` reports small closed traces at or below an area
+  threshold (um^2, measured the way the object and trace tables measure it).
+* ``Series.findEmptyTraces`` reports traces with no geometry at all: no points, a
+  closed trace enclosing zero area, an open trace of zero length.
+* ``Series.deleteDuplicateTraces`` is the pre-existing same-name operation. It is
+  covered here because ``Trace.getOverlapRatio`` used to divide by zero on
+  degenerate traces and take the whole pass down with it.
+
+Neither scan modifies anything: removal goes through
+``Series.deleteMalformedTraces``, which re-finds each trace by a color plus
+rounded-points signature, so one confirmation removes exactly the reviewed
+traces and one undo puts them back.
+"""
+
+import pytest
+
+from PyReconstruct.modules.datatypes.trace import Trace
+
+
+def _template(section):
+    """A real closed trace from the section, to copy display attributes from."""
+    for cname in section.contours:
+        for trace in section.contours[cname]:
+            if trace.closed and len(trace.points) >= 3:
+                return trace
+    pytest.skip("no closed trace in the fixture section")
+
+
+def _add(series, snum, name, points, closed=True):
+    """Add a synthetic trace to a section and save it.
+
+    Returns nothing: every assertion below re-reads the section through the
+    scans, so a trace that did not survive ``addTrace`` shows up as a scan that
+    finds nothing rather than as a stale object that looks fine.
+    """
+    section = series.loadSection(snum)
+    template = _template(section)
+    trace = Trace(name, template.color, closed=closed)
+    trace.points = list(points)
+    section.addTrace(trace, log_event=False)
+    section.save()
+
+
+def _square(cx, cy, half):
+    """A closed square centered on (cx, cy)."""
+    return [
+        (cx - half, cy - half),
+        (cx + half, cy - half),
+        (cx + half, cy + half),
+        (cx - half, cy + half),
+    ]
+
+
+def _first_section(series):
+    return sorted(series.sections.keys())[0]
+
+
+# --------------------------------------------------------------------------
+# pixel dust
+# --------------------------------------------------------------------------
+
+def test_a_small_closed_trace_is_reported_as_pixel_dust(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "dust", _square(20, 20, 0.01))
+
+    found = real_series.findPixelDustTraces(0.01)
+
+    assert [r["name"] for r in found] == ["dust"]
+    assert found[0]["section"] == snum
+    assert found[0]["area"] > 0
+
+
+def test_a_large_trace_is_not_pixel_dust(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "big", _square(20, 20, 2.0))
+
+    found = real_series.findPixelDustTraces(0.01)
+
+    assert "big" not in {r["name"] for r in found}
+
+
+def test_the_area_threshold_includes_its_own_edge(real_series):
+    """At or below, not below: a trace whose area equals the threshold goes."""
+    snum = _first_section(real_series)
+    _add(real_series, snum, "edge", _square(20, 20, 0.05))
+
+    section = real_series.loadSection(snum)
+    trace = section.contours["edge"][0]
+    exact = real_series._traceArea(trace, section.tform)
+
+    assert "edge" in {r["name"] for r in real_series.findPixelDustTraces(exact)}
+    assert "edge" not in {
+        r["name"] for r in real_series.findPixelDustTraces(exact * 0.99)
+    }
+
+
+def test_open_traces_are_never_pixel_dust(real_series):
+    """An open trace encloses no area, so an area threshold cannot judge it."""
+    snum = _first_section(real_series)
+    _add(real_series, snum, "line", [(30, 30), (30.001, 30), (30.002, 30)],
+         closed=False)
+
+    found = real_series.findPixelDustTraces(1.0)
+
+    assert "line" not in {r["name"] for r in found}
+
+
+def test_zero_area_traces_are_left_to_the_empty_scan(real_series):
+    """The two scans stay disjoint, so nothing is reported by both."""
+    snum = _first_section(real_series)
+    _add(real_series, snum, "flat", [(40, 40), (41, 40), (42, 40)])
+
+    dust = {r["name"] for r in real_series.findPixelDustTraces(1.0)}
+    empty = {r["name"] for r in real_series.findEmptyTraces()}
+
+    assert "flat" not in dust
+    assert "flat" in empty
+    assert not (dust & empty)
+
+
+def test_locked_objects_are_skipped_by_the_pixel_dust_scan(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "dust", _square(20, 20, 0.01))
+    real_series.setAttr("dust", "locked", True)
+
+    assert real_series.findPixelDustTraces(0.01) == []
+    assert "dust" in {
+        r["name"] for r in real_series.findPixelDustTraces(
+            0.01, include_locked=True
+        )
+    }
+
+
+def test_the_pixel_dust_scan_modifies_nothing(real_series):
+    """A scan is a report. Running it must leave every trace where it was."""
+    snum = _first_section(real_series)
+    _add(real_series, snum, "dust", _square(20, 20, 0.01))
+
+    before = {
+        n: [list(t.points) for t in real_series.loadSection(n).contours[c]]
+        for n in sorted(real_series.sections.keys())
+        for c in real_series.loadSection(n).contours
+    }
+
+    real_series.findPixelDustTraces(0.01)
+    real_series.findEmptyTraces()
+
+    after = {
+        n: [list(t.points) for t in real_series.loadSection(n).contours[c]]
+        for n in sorted(real_series.sections.keys())
+        for c in real_series.loadSection(n).contours
+    }
+    assert before == after
+
+
+def test_deleting_reviewed_records_removes_exactly_those_traces(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "dust", _square(20, 20, 0.01))
+    _add(real_series, snum, "keep", _square(25, 25, 0.01))
+
+    found = real_series.findPixelDustTraces(0.01)
+    chosen = [r for r in found if r["name"] == "dust"]
+    assert len(chosen) == 1
+
+    deleted = real_series.deleteMalformedTraces(
+        chosen, message="Removing pixel-dust traces..."
+    )
+
+    assert [r["name"] for r in deleted] == ["dust"]
+    contours = real_series.loadSection(snum).contours
+    assert "dust" not in contours or len(contours["dust"]) == 0
+    assert len(contours["keep"]) == 1
+
+
+def test_a_record_still_matches_its_trace_after_a_save_and_reload(real_series):
+    """The signature is color plus 7-decimal points, not object identity."""
+    snum = _first_section(real_series)
+    _add(real_series, snum, "dust", _square(20, 20, 0.01))
+
+    record = real_series.findPixelDustTraces(0.01)[0]
+    section = real_series.loadSection(snum)
+    section.save()
+
+    reloaded = real_series.loadSection(snum).contours["dust"][0]
+    assert real_series._traceMatchesSignature(reloaded, record["match"])
+
+
+# --------------------------------------------------------------------------
+# empty traces
+# --------------------------------------------------------------------------
+
+def test_a_closed_trace_enclosing_zero_area_is_empty(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "collinear", [(40, 40), (41, 40), (42, 40)])
+
+    found = {r["name"]: r for r in real_series.findEmptyTraces()}
+
+    assert "collinear" in found
+    assert found["collinear"]["reason"] == "Closed trace enclosing zero area"
+
+
+def test_an_open_trace_of_zero_length_is_empty(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "coincident", [(50, 50), (50, 50), (50, 50)],
+         closed=False)
+
+    found = {r["name"]: r for r in real_series.findEmptyTraces()}
+
+    assert "coincident" in found
+    assert found["coincident"]["reason"] == "Open trace of zero length"
+
+
+def test_real_traces_are_not_reported_as_empty(real_series):
+    """The fixture's own shapes all enclose area, so none of them qualify."""
+    found = {r["name"] for r in real_series.findEmptyTraces()}
+
+    section = real_series.loadSection(_first_section(real_series))
+    real_names = {
+        c for c in section.contours
+        if any(len(t.points) >= 3 for t in section.contours[c])
+    }
+    assert not (found & real_names)
+
+
+def test_locked_objects_are_skipped_by_the_empty_scan(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "collinear", [(40, 40), (41, 40), (42, 40)])
+    real_series.setAttr("collinear", "locked", True)
+
+    assert "collinear" not in {r["name"] for r in real_series.findEmptyTraces()}
+    assert "collinear" in {
+        r["name"] for r in real_series.findEmptyTraces(include_locked=True)
+    }
+
+
+def test_empty_traces_are_removed_by_the_shared_delete_path(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "collinear", [(40, 40), (41, 40), (42, 40)])
+
+    records = [
+        r for r in real_series.findEmptyTraces() if r["name"] == "collinear"
+    ]
+    deleted = real_series.deleteMalformedTraces(
+        records, message="Removing empty traces..."
+    )
+
+    assert [r["name"] for r in deleted] == ["collinear"]
+    contours = real_series.loadSection(snum).contours
+    assert "collinear" not in contours or len(contours["collinear"]) == 0
+
+
+# --------------------------------------------------------------------------
+# the zero-area guard in getOverlapRatio
+# --------------------------------------------------------------------------
+
+def _trace(points, closed=True, name="t"):
+    t = Trace(name, (255, 0, 0), closed=closed)
+    t.points = list(points)
+    return t
+
+
+@pytest.mark.parametrize("a, b", [
+    # both traces confined to one horizontal line
+    ([(0, 0), (1, 0), (2, 0)], [(0, 0), (3, 0), (4, 0)]),
+    # both confined to one vertical line
+    ([(0, 0), (0, 1), (0, 2)], [(0, 0), (0, 3), (0, 4)]),
+    # a single point and a run passing through it
+    ([(5, 5)], [(5, 5), (5, 6), (5, 7)]),
+])
+def test_a_collapsed_bounding_box_answers_zero_rather_than_raising(a, b):
+    """The combined box has no area, so there is no area to compare.
+
+    ``getOverlapRatio`` picks its raster scale from the combined bounding box
+    area. Two traces on one line collapse that box, and the scale factor used to
+    divide by it.
+    """
+    assert _trace(a).getOverlapRatio(_trace(b)) == 0
+    assert _trace(b).getOverlapRatio(_trace(a)) == 0
+
+
+@pytest.mark.parametrize("threshold", [0, 0.5, 0.95, 1])
+def test_overlaps_answers_for_collinear_traces_at_every_threshold(threshold):
+    a = _trace([(0, 0), (1, 0), (2, 0)])
+    b = _trace([(0, 0), (3, 0), (4, 0)])
+
+    assert a.overlaps(b, threshold=threshold) is False
+
+
+def test_identical_degenerate_traces_are_still_duplicates():
+    """Settled on points before a ratio is ever asked for, so the guard is safe."""
+    a = _trace([(0, 0), (1, 0), (2, 0)])
+    b = _trace([(0, 0), (1, 0), (2, 0)])
+
+    assert a.overlaps(b, threshold=0.95) is True
+
+
+def test_the_duplicate_pass_survives_a_degenerate_trace(real_series):
+    """The crash this guards: one such pair ended the whole pass.
+
+    Two collinear traces under one name used to raise ``ZeroDivisionError`` out
+    of ``getOverlapRatio``, through ``overlaps``, and out of
+    ``deleteDuplicateTraces``, so no section after the first offender was
+    scanned and nothing was cleaned up.
+    """
+    snum = _first_section(real_series)
+    _add(real_series, snum, "flat", [(60, 60), (61, 60), (62, 60)])
+    _add(real_series, snum, "flat", [(60, 60), (63, 60), (64, 60)])
+
+    real_series.deleteDuplicateTraces(0.95, include_locked=True)
+
+    # both survive: they are not duplicates of each other
+    assert len(real_series.loadSection(snum).contours["flat"]) == 2
+
+
+def test_identical_degenerate_duplicates_are_still_collapsed(real_series):
+    snum = _first_section(real_series)
+    _add(real_series, snum, "flat", [(60, 60), (61, 60), (62, 60)])
+    _add(real_series, snum, "flat", [(60, 60), (61, 60), (62, 60)])
+
+    real_series.deleteDuplicateTraces(0.95, include_locked=True)
+
+    assert len(real_series.loadSection(snum).contours["flat"]) == 1
+
+
+# --------------------------------------------------------------------------
+# the menu
+# --------------------------------------------------------------------------
+
+class _Stub:
+    """Answers any attribute with another stub, so the menu tree can be built.
+
+    ``return_series_menu`` reads a handler off the window for every row. The
+    tree is data, so building it against a stub is enough to assert what rows
+    exist and which attribute name each one points at.
+    """
+
+    def __getattr__(self, name):
+        child = _Stub()
+        object.__setattr__(self, name, child)
+        return child
+
+    def __call__(self, *args, **kwargs):
+        return None
+
+
+def _menu_rows(tree, path=()):
+    if isinstance(tree, dict):
+        for opt in tree.get("opts", []):
+            yield from _menu_rows(opt, path + (tree.get("text", ""),))
+    elif isinstance(tree, tuple):
+        yield path, tree
+
+
+@pytest.fixture
+def series_menu(qapp):
+    from PyReconstruct.modules.gui.main.menubar import return_series_menu
+
+    return list(_menu_rows(return_series_menu(_Stub())))
+
+
+def test_the_clean_up_submenu_holds_the_four_operations(series_menu):
+    rows = [r for p, r in series_menu if "Clean up" in p]
+
+    assert [r[0] for r in rows] == [
+        "removeduplicates_act",
+        "finddiffnamedduplicates_act",
+        "removepixeldust_act",
+        "removeempty_act",
+    ]
+
+
+def test_each_clean_up_row_is_wired_to_its_own_handler(series_menu):
+    """The rows must not share a slot, which a copy-paste error would produce."""
+    from PyReconstruct.modules.gui.main.main_window import MainWindow
+
+    expected = {
+        "removeduplicates_act": "deleteDuplicateTraces",
+        "finddiffnamedduplicates_act": "findDifferentlyNamedDuplicates",
+        "removepixeldust_act": "removePixelDustTraces",
+        "removeempty_act": "removeEmptyTraces",
+    }
+    rows = {r[0]: r for p, r in series_menu if "Clean up" in p}
+
+    for act, handler in expected.items():
+        assert act in rows
+        assert hasattr(MainWindow, handler), f"{handler} missing on MainWindow"
+
+
+def test_removing_duplicates_is_reachable_only_from_the_clean_up_submenu(
+    series_menu
+):
+    """It moved into the submenu rather than being duplicated into it."""
+    rows = [(p, r) for p, r in series_menu if r[0] == "removeduplicates_act"]
+
+    assert len(rows) == 1
+    assert "Clean up" in rows[0][0]


### PR DESCRIPTION
Adds a `Clean up` submenu under Series holding the data-maintenance operations, with the two scans #67 asks for and the cross-name scan #109 asks for.

`Remove pixel-dust traces` lists small closed traces at or below an area threshold (um^2, as the object and trace tables measure it) for review, so nothing goes until the user deselects what to keep. `Remove empty traces` takes degenerate geometry only: no points, zero-area closed, zero-length open.

`Find duplicates named differently` is a new scan rather than a change to the overlap test. `Trace.overlaps` never reads a name; the same-name restriction comes from `deleteDuplicateTraces` drawing both traces out of one `section.contours[cname]`, so two differently-named traces were never compared. It reports and does not delete, because which of the two names is right can turn on hosts, groups or curation, and the answer may be to rename or to merge.

Stops `getOverlapRatio` dividing by zero when the combined bounding box collapses, which two collinear traces did, ending the duplicate pass on the first such pair.

Includes tests. The repo has no `tests/` directory yet, so this adds one in the shape #129 uses.

Closes #67
Closes #109
